### PR TITLE
Use image placeholders to optimize token usage in blog generation

### DIFF
--- a/backend/infrastructure/gemini/gemini_blog_post_generator.py
+++ b/backend/infrastructure/gemini/gemini_blog_post_generator.py
@@ -246,8 +246,12 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 
 	@staticmethod
 	def _replace_placeholders(content: str, placeholder_map: dict[str, str]) -> str:
-		"""Replace IMG_N placeholders with actual Supabase URLs."""
-		for placeholder, url in placeholder_map.items():
+		"""Replace IMG_N placeholders with actual Supabase URLs.
+
+		Sort by key length descending so IMG_10 is replaced before IMG_1,
+		avoiding substring collisions with multi-digit indices.
+		"""
+		for placeholder, url in sorted(placeholder_map.items(), key=lambda x: len(x[0]), reverse=True):
 			content = content.replace(placeholder, url)
 		return content
 

--- a/backend/infrastructure/gemini/gemini_blog_post_generator.py
+++ b/backend/infrastructure/gemini/gemini_blog_post_generator.py
@@ -54,8 +54,7 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 
 		# 注意事項
 		- Markdown のセクションヘッダは `##` から使用してください（`#` はタイトル用）
-		- 図が提供されている場合は、適切な位置に `![図の説明](IMG_N)` の形式で埋め込んでください（IMG_N は提供されたプレースホルダ番号）
-		- プレースホルダ（IMG_1, IMG_2, ...）はそのまま記述し、URL に書き換えないでください
+		- 図は `![説明](IMG_N)` で埋め込む（IMG_N はそのまま記述）
 		- 数式は KaTeX 互換の LaTeX 記法で記述してください。以下のルールを厳守すること：
 		- インライン数式は `$...$`、ブロック数式は `$$...$$` で囲む
 		- ブロック数式の `$$` の前後には必ず空行を入れること（Markdown パーサがブロックとして認識するために必須）。例：
@@ -108,8 +107,7 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 
 		# content の Markdown 注意事項
 		- セクションヘッダは `##` から使用（`#` はタイトル用）
-		- 図が提供されている場合は、適切な位置に `![図の説明](IMG_N)` の形式で埋め込む（IMG_N は提供されたプレースホルダ番号）
-		- プレースホルダ（IMG_1, IMG_2, ...）はそのまま記述し、URL に書き換えないこと
+		- 図は `![説明](IMG_N)` で埋め込む（IMG_N はそのまま記述）
 		- 数式は KaTeX 互換の LaTeX 記法で記述。以下のルールを厳守：
 		  - インライン数式: `$...$`、ブロック数式: `$$...$$`
 		  - ブロック数式の `$$` 前後には必ず空行を入れること
@@ -142,16 +140,16 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 				self.logger.warning('Failed to read %s', tex_file, exc_info=True)
 		latex_content = '\n\n'.join(tex_parts)
 
-		# 図URL一覧セクション（プレースホルダを使用してトークン節約）
+		# 図URL一覧セクション（プレースホルダを使用）
 		figure_section = ''
 		placeholder_map: dict[str, str] = {}
 		if figure_urls:
-			lines = ['# 利用可能な図の一覧（プレースホルダ → 実際のURLに後処理で置換）\n']
+			lines = ['# 利用可能な図\n']
 			for i, (filename, url) in enumerate(figure_urls.items(), 1):
 				placeholder = f'IMG_{i}'
 				placeholder_map[placeholder] = url
-				lines.append(f'- {filename} → プレースホルダ: {placeholder}')
-			lines.append('\n図を埋め込む際は ![図の説明](IMG_N) の形式でプレースホルダをそのまま使用してください。\n')
+				lines.append(f'- {filename}: {placeholder}')
+			lines.append('')
 			figure_section = '\n'.join(lines)
 
 		authors_str = ', '.join(a.name for a in paper_metadata.authors)
@@ -187,7 +185,7 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 		figure_section = ''
 		placeholder_map: dict[str, str] = {}
 		if figures:
-			lines = ['# 利用可能な図の一覧（プレースホルダ → 実際のURLに後処理で置換）\n']
+			lines = ['# 利用可能な図\n']
 			for i, fig in enumerate(figures, 1):
 				placeholder = f'IMG_{i}'
 				placeholder_map[placeholder] = fig.url
@@ -196,15 +194,14 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 					if fig.figure_number
 					else f'図 (p.{fig.page_number})'
 				)
-				caption_part = f': "{fig.caption}"' if fig.caption else ''
-				lines.append(f'- {label} (p.{fig.page_number}){caption_part} → プレースホルダ: {placeholder}')
-			lines.append('\n図を埋め込む際は ![図の説明](IMG_N) の形式でプレースホルダをそのまま使用してください。\n')
+				caption_part = f' "{fig.caption}"' if fig.caption else ''
+				lines.append(f'- {label} p.{fig.page_number}{caption_part}: {placeholder}')
+			lines.append('')
 			figure_section = '\n'.join(lines)
 
 		user_prompt = (
 			f'{figure_section}'
-			'添付の PDF 論文を読み、メタデータ（title, authors, summary）と日本語ブログ記事（content）を返してください。\n'
-			'図を参照する際は、上記の一覧に記載されたプレースホルダ（IMG_N）をそのまま使用してください。'
+			'添付の PDF 論文を読み、メタデータ（title, authors, summary）と日本語ブログ記事（content）を返してください。'
 		)
 
 		self.logger.info('Uploading PDF to Gemini Files API: %s', pdf_path.name)

--- a/backend/infrastructure/gemini/gemini_blog_post_generator.py
+++ b/backend/infrastructure/gemini/gemini_blog_post_generator.py
@@ -54,8 +54,8 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 
 		# 注意事項
 		- Markdown のセクションヘッダは `##` から使用してください（`#` はタイトル用）
-		- 図が提供されている場合は、適切な位置に `![図の説明](URL)` として埋め込んでください
-		- 画像URL（png/jpg/webp/svg など）のみ `![...]` で埋め込み、PDF URL は `[図の説明](URL)` の通常リンクにしてください
+		- 図が提供されている場合は、適切な位置に `![図の説明](IMG_N)` の形式で埋め込んでください（IMG_N は提供されたプレースホルダ番号）
+		- プレースホルダ（IMG_1, IMG_2, ...）はそのまま記述し、URL に書き換えないでください
 		- 数式は KaTeX 互換の LaTeX 記法で記述してください。以下のルールを厳守すること：
 		- インライン数式は `$...$`、ブロック数式は `$$...$$` で囲む
 		- ブロック数式の `$$` の前後には必ず空行を入れること（Markdown パーサがブロックとして認識するために必須）。例：
@@ -108,8 +108,8 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 
 		# content の Markdown 注意事項
 		- セクションヘッダは `##` から使用（`#` はタイトル用）
-		- 図が提供されている場合は、適切な位置に `![図の説明](URL)` として埋め込む
-		- 画像URL のみ `![...]` で埋め込み、PDF URL は `[図の説明](URL)` の通常リンクにする
+		- 図が提供されている場合は、適切な位置に `![図の説明](IMG_N)` の形式で埋め込む（IMG_N は提供されたプレースホルダ番号）
+		- プレースホルダ（IMG_1, IMG_2, ...）はそのまま記述し、URL に書き換えないこと
 		- 数式は KaTeX 互換の LaTeX 記法で記述。以下のルールを厳守：
 		  - インライン数式: `$...$`、ブロック数式: `$$...$$`
 		  - ブロック数式の `$$` 前後には必ず空行を入れること
@@ -142,13 +142,16 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 				self.logger.warning('Failed to read %s', tex_file, exc_info=True)
 		latex_content = '\n\n'.join(tex_parts)
 
-		# 図URL一覧セクション
+		# 図URL一覧セクション（プレースホルダを使用してトークン節約）
 		figure_section = ''
+		placeholder_map: dict[str, str] = {}
 		if figure_urls:
-			lines = ['# 利用可能な図のURL\n']
-			for filename, url in figure_urls.items():
-				lines.append(f'- {filename}: {url}')
-			lines.append('\n')
+			lines = ['# 利用可能な図の一覧（プレースホルダ → 実際のURLに後処理で置換）\n']
+			for i, (filename, url) in enumerate(figure_urls.items(), 1):
+				placeholder = f'IMG_{i}'
+				placeholder_map[placeholder] = url
+				lines.append(f'- {filename} → プレースホルダ: {placeholder}')
+			lines.append('\n図を埋め込む際は ![図の説明](IMG_N) の形式でプレースホルダをそのまま使用してください。\n')
 			figure_section = '\n'.join(lines)
 
 		authors_str = ', '.join(a.name for a in paper_metadata.authors)
@@ -173,7 +176,8 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 			contents=user_prompt,
 		)
 
-		return self._extract_markdown(response.text or '')
+		content = self._extract_markdown(response.text or '')
+		return self._replace_placeholders(content, placeholder_map)
 
 	async def generate_from_pdf(
 		self,
@@ -181,25 +185,26 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 		figures: list[UploadedFigure],
 	) -> tuple[PdfPaperMetadata, str]:
 		figure_section = ''
+		placeholder_map: dict[str, str] = {}
 		if figures:
-			lines = ['# 利用可能な図の一覧\n']
-			for fig in figures:
+			lines = ['# 利用可能な図の一覧（プレースホルダ → 実際のURLに後処理で置換）\n']
+			for i, fig in enumerate(figures, 1):
+				placeholder = f'IMG_{i}'
+				placeholder_map[placeholder] = fig.url
 				label = (
 					f'Figure {fig.figure_number}'
 					if fig.figure_number
 					else f'図 (p.{fig.page_number})'
 				)
 				caption_part = f': "{fig.caption}"' if fig.caption else ''
-				lines.append(
-					f'- {label} (p.{fig.page_number}){caption_part} → ![{label}]({fig.url})'
-				)
-			lines.append('\n')
+				lines.append(f'- {label} (p.{fig.page_number}){caption_part} → プレースホルダ: {placeholder}')
+			lines.append('\n図を埋め込む際は ![図の説明](IMG_N) の形式でプレースホルダをそのまま使用してください。\n')
 			figure_section = '\n'.join(lines)
 
 		user_prompt = (
 			f'{figure_section}'
 			'添付の PDF 論文を読み、メタデータ（title, authors, summary）と日本語ブログ記事（content）を返してください。\n'
-			'図を参照する際は、上記の一覧に記載された URL をそのまま使用してください。'
+			'図を参照する際は、上記の一覧に記載されたプレースホルダ（IMG_N）をそのまま使用してください。'
 		)
 
 		self.logger.info('Uploading PDF to Gemini Files API: %s', pdf_path.name)
@@ -235,11 +240,19 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 			authors=parsed.authors,
 			summary=parsed.summary,
 		)
-		return metadata, self._ensure_math_blank_lines(parsed.content)
+		content = self._ensure_math_blank_lines(parsed.content)
+		return metadata, self._replace_placeholders(content, placeholder_map)
 
 	# ------------------------------------------------------------------
-	# Markdown extraction helpers
+	# Markdown extraction / post-processing helpers
 	# ------------------------------------------------------------------
+
+	@staticmethod
+	def _replace_placeholders(content: str, placeholder_map: dict[str, str]) -> str:
+		"""Replace IMG_N placeholders with actual Supabase URLs."""
+		for placeholder, url in placeholder_map.items():
+			content = content.replace(placeholder, url)
+		return content
 
 	def _extract_markdown(self, raw_text: str) -> str:
 		"""Extract Markdown content from Gemini response and post-process."""

--- a/backend/infrastructure/supabase/supabase_figure_storage_repository.py
+++ b/backend/infrastructure/supabase/supabase_figure_storage_repository.py
@@ -91,8 +91,8 @@ class SupabaseFigureStorageRepository(IFigureStorageRepository):
 				public_url = await supabase.storage.from_(self._bucket_name).get_public_url(
 					storage_path
 				)
-				figure_urls[figure_file.name] = public_url
-				self._logger.info('Uploaded figure %s → %s', figure_file.name, public_url)
+				figure_urls[storage_filename] = public_url
+				self._logger.info('Uploaded figure %s → %s', storage_filename, public_url)
 			except Exception:
 				self._logger.warning(
 					'Failed to upload figure %s, skipping', figure_file.name, exc_info=True


### PR DESCRIPTION
## Summary
Refactored the blog post generation system to use image placeholders (IMG_1, IMG_2, etc.) instead of embedding full URLs directly in prompts. This reduces token consumption when processing documents with multiple figures while maintaining the ability to replace placeholders with actual URLs in post-processing.

## Key Changes

- **Placeholder-based image references**: Modified system prompts to instruct Gemini to use `![description](IMG_N)` format instead of full URLs
- **Placeholder mapping**: Introduced `placeholder_map` dictionary in both `generate()` and `generate_from_pdf()` methods to track placeholder-to-URL mappings
- **Post-processing replacement**: Added `_replace_placeholders()` static method to replace all placeholders with actual Supabase URLs after content generation
- **Updated figure section formatting**: Changed figure list presentation to show placeholder assignments instead of embedding URLs directly
- **Fixed storage filename tracking**: Corrected `supabase_figure_storage_repository.py` to use `storage_filename` (with paper_id prefix) instead of original `figure_file.name` for consistency in URL mapping

## Implementation Details

- The placeholder replacement happens as a final post-processing step after Markdown extraction
- Both `generate()` and `generate_from_pdf()` methods now follow the same placeholder pattern
- System prompts explicitly instruct the model to preserve placeholders as-is without URL substitution
- This approach significantly reduces prompt token usage for documents with many figures while maintaining full URL functionality in the final output

https://claude.ai/code/session_01M84PBj3MdLrCWGDsEyW2d6