### PR TITLE
fix: MuPDF カラースペース解析エラーを修正

### DIFF
--- a/pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py
+++ b/pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py
@@ -52,7 +52,7 @@ class PdfFigureExtractor(FigureExtractorGateway):
 
                 page = doc[page_num]
 
-                pix = page.get_pixmap(matrix=fitz.Matrix(scale, scale))
+                pix = page.get_pixmap(matrix=fitz.Matrix(scale, scale), colorspace=fitz.csRGB)
                 page_img = Image.open(io.BytesIO(pix.tobytes("png")))
 
                 img_bgr = cv2.cvtColor(np.array(page_img), cv2.COLOR_RGB2BGR)

--- a/pdf_analysis/infrastructure/pdf_parse/pdf_chunker.py
+++ b/pdf_analysis/infrastructure/pdf_parse/pdf_chunker.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import fitz
 import pymupdf4llm
 from llama_index.core import Document
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
@@ -21,7 +22,9 @@ class PyMuPdfChunker(PdfChunkerGateway):
     CHUNK_OVERLAP = 50
 
     def chunk_pdf(self, pdf_path: Path) -> list[TextChunk]:
+        fitz.TOOLS.mupdf_display_errors(False)
         raw_chunks = pymupdf4llm.to_markdown(str(pdf_path), page_chunks=True)
+        fitz.TOOLS.mupdf_display_errors(True)
 
         llama_docs = [
             Document(

--- a/pdf_analysis/infrastructure/pdf_parse/pdf_chunker.py
+++ b/pdf_analysis/infrastructure/pdf_parse/pdf_chunker.py
@@ -23,8 +23,10 @@ class PyMuPdfChunker(PdfChunkerGateway):
 
     def chunk_pdf(self, pdf_path: Path) -> list[TextChunk]:
         fitz.TOOLS.mupdf_display_errors(False)
-        raw_chunks = pymupdf4llm.to_markdown(str(pdf_path), page_chunks=True)
-        fitz.TOOLS.mupdf_display_errors(True)
+        try:
+            raw_chunks = pymupdf4llm.to_markdown(str(pdf_path), page_chunks=True)
+        finally:
+            fitz.TOOLS.mupdf_display_errors(True)
 
         llama_docs = [
             Document(


### PR DESCRIPTION
## Summary
- 非標準・不正なカラースペース定義を持つPDFを処理する際に発生する `MuPDF error: syntax error: could not parse color space` を修正する
- `get_pixmap()` に明示的なRGBカラースペースを指定することで、MuPDFが問題のあるカラースペースオブジェクトを解析しようとするのを回避する
- テキスト抽出時にも同様のエラー出力が発生しないよう、`pymupdf4llm.to_markdown()` 前後でエラー表示を制御する

## Changes
- `pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py` — `page.get_pixmap()` に `colorspace=fitz.csRGB` を追加
- `pdf_analysis/infrastructure/pdf_parse/pdf_chunker.py` — `fitz` をインポートし、`to_markdown()` 前後で `mupdf_display_errors` を制御

## Test plan
- [ ] 非標準カラースペース（ICC Profile等）を含むPDFを図形抽出エンドポイントに送信し、エラーメッセージが出なくなることを確認
- [ ] 同じPDFをチャンク分割エンドポイントに送信し、テキスト抽出が正常に完了することを確認
- [ ] 通常のPDF（sRGB）で既存の動作が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)