### PR TITLE
fix: update default Gemini model selection

### DIFF
--- a/backend/infrastructure/gemini/gemini_blog_post_generator.py
+++ b/backend/infrastructure/gemini/gemini_blog_post_generator.py
@@ -33,7 +33,7 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 	def __init__(
 		self,
 		api_key: str,
-		model: str = 'gemini-2.5-flash',
+		model: str = 'gemini-2.5-flash-lite',
 		max_latex_chars: int = 80_000,
 	):
 		self.client = genai.Client(api_key=api_key)


### PR DESCRIPTION
## Summary
- Geminiブログ生成で古いモデル指定が残っていたため、デフォルトモデルを現行の軽量推論向けモデルへ更新して安定運用しやすくします。
- モデル指定を実運用に合わせることで、生成失敗や不要な設定差分を減らし、保守コストを下げます。

## Changes
- `backend/infrastructure/gemini/gemini_blog_post_generator.py` のデフォルトモデル値を `gemini-2.5-flash-lite` に変更

## Test plan
- [ ] `GeminiBlogPostGenerator` をデフォルト設定で初期化し、`model_name` が `gemini-2.5-flash-lite` になることを確認
- [ ] ブログ生成フローを1回実行し、モデル未指定時でも正常にレスポンスが返ることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Made with [Cursor](https://cursor.com)