### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Architecture overview
+
+jaXiv is a multi-service application for translating arXiv papers (English → Japanese) and generating blog posts from academic PDFs. It consists of:
+
+| Service | Tech | Port | Directory |
+|---------|------|------|-----------|
+| Backend API | FastAPI (Python 3.13, uv) | 8000 | `backend/` |
+| PDF Analysis | FastAPI (Python 3.13, uv) | 7860 | `pdf_analysis/` |
+| Frontend | React Router + Cloudflare Workers (Node, npm) | 5173 | `frontend/` |
+| PostgreSQL | Docker (postgres:16-alpine) | 5434 (host) | via `docker-compose.yml` |
+| Qdrant | Docker (qdrant/qdrant) | 6333 | via `docker-compose.yml` |
+
+### Starting infrastructure services
+
+```bash
+# Start PostgreSQL and Qdrant (required by backend)
+docker compose up -d db qdrant
+
+# Run DB migrations (from backend/)
+cd backend && uv run alembic upgrade head
+```
+
+### Starting application services
+
+```bash
+# Backend API (from backend/)
+uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+
+# PDF Analysis (from pdf_analysis/)
+uv run uvicorn main:app --host 0.0.0.0 --port 7860 --reload
+
+# Frontend dev server (from frontend/) — requires CLOUDFLARE_API_TOKEN (see note below)
+npm run dev
+```
+
+### Backend .env file
+
+The backend requires a `.env` file at `backend/.env`. Key variables:
+
+- `POSTGRES_URL` — set to `postgresql://jaxiv:jaxiv@localhost:5434/jaxiv` for local Docker
+- `QDRANT_URL` — set to `http://localhost:6333`
+- `LAYOUT_ANALYSIS_URL` — set to `http://localhost:7860`
+- `SUPABASE_URL`, `SUPABASE_KEY`, `BUCKET_NAME`, `BLOG_FIGURES_BUCKET_NAME` — Supabase storage (required for PDF/blog storage features)
+- `MISTRAL_API_KEY` — Mistral AI API key (required for translation)
+- `GEMINI_API_KEY` — Google Gemini API key (required for blog generation)
+- `QDRANT_API_KEY` — Qdrant API key
+
+### Lint and type check commands
+
+See `frontend/package.json` scripts and `backend/pyproject.toml` / `pdf_analysis/pyproject.toml` dev dependencies. Key commands:
+
+- **Frontend**: `npm run lint` (ESLint), `npm run typecheck` (react-router typegen + tsc)
+- **Backend**: `uv run ruff check .`, `uv run mypy .`
+- **PDF Analysis**: `uv run ruff check .`, `uv run mypy .` (has pre-existing mypy errors from `transformers` stubs)
+
+### Important caveats
+
+- **Frontend dev server requires Cloudflare authentication**: `npm run dev` uses the `@cloudflare/vite-plugin` which requires a valid `CLOUDFLARE_API_TOKEN` env var (or `wrangler login`) because the Workers AI binding (`ai.binding` in `wrangler.jsonc`) always connects remotely. Without it, the dev server times out. The frontend **builds** correctly without credentials (`npm run build`).
+- **React Router typegen**: Before running `npx tsc --noEmit`, you must first run `npx react-router typegen` to generate route types (`app/+types/`). The `npm run typecheck` script does both.
+- **pdf_analysis mypy**: Has 6 pre-existing false positive errors from `transformers` library stubs (`AutoTokenizer`, `AutoModel`, `AutoImageProcessor` not callable). These are expected and not regressions.
+- **Qdrant API key warning**: When using a placeholder `QDRANT_API_KEY` with local Qdrant (non-TLS), you'll see a `UserWarning: Api key is used with an insecure connection` warning. This is harmless in local dev.
+- **DDD architecture**: The codebase follows Domain-Driven Design with Onion/Clean Architecture. See `.cursor/rules/implementation.mdc` for detailed conventions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor Cloud 開発環境のセットアップドキュメント (`AGENTS.md`) を追加します。

### 変更内容

- `AGENTS.md` を新規作成: Cloud Agent が開発環境を正しくセットアップ・起動するための手順と注意事項を記載

### AGENTS.md に含まれる情報

- サービスアーキテクチャの概要（Backend API, PDF Analysis, Frontend, PostgreSQL, Qdrant）
- インフラ・アプリケーション起動手順
- `backend/.env` の環境変数一覧
- lint / type check コマンド
- 重要な注意点（Cloudflare認証、React Router typegen、pdf_analysis mypy、DDD規約 等）

### 検証結果

開発環境のセットアップを実行し、以下のサービスが正常に動作することを確認:

| Service | Status | Port |
|---------|--------|------|
| Backend API (FastAPI) | ✅ Running | 8000 |
| PDF Analysis (FastAPI) | ✅ Running | 7860 |
| PostgreSQL (Docker) | ✅ Healthy | 5434 |
| Qdrant (Docker) | ✅ Running | 6333 |
| Frontend (Cloudflare Workers) | ⚠️ Build OK, dev server requires `CLOUDFLARE_API_TOKEN` | 5173 |

[Backend API Swagger UI](https://cursor.com/agents/bc-a2152b17-1b35-49e4-887d-b0e6f68f3b0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_api_docs.webp)
[PDF Analysis API docs](https://cursor.com/agents/bc-a2152b17-1b35-49e4-887d-b0e6f68f3b0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpdf_analysis_docs.webp)
[Qdrant dashboard](https://cursor.com/agents/bc-a2152b17-1b35-49e4-887d-b0e6f68f3b0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqdrant_dashboard.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2152b17-1b35-49e4-887d-b0e6f68f3b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2152b17-1b35-49e4-887d-b0e6f68f3b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

