### PR TITLE
Refactor message truncation logic and remove user ownership check

### DIFF
--- a/backend/application/usecase/chat_with_paper.py
+++ b/backend/application/usecase/chat_with_paper.py
@@ -20,7 +20,6 @@ from application.chat_events import (
 )
 from application.unit_of_works.chat_thread_unit_of_work import ChatThreadUnitOfWork
 from domain.entities.chat import ChatMessage, ToolCall
-from domain.errors.domain_error import ChatThreadNotFoundError
 from domain.gateways.i_chat_llm_gateway import IChatLLMGateway, ToolCallItem, ToolDefinition
 
 from .rag_search_image import RagSearchImageResult, RagSearchImageUseCase
@@ -55,19 +54,7 @@ RAG_TOOLS: list[ToolDefinition] = [
 ]
 
 MAX_TOOL_ROUNDS = 3
-# 0 以下なら無制限。古いメッセージから順に切り捨て、tool_call と tool_result の
-# 対応関係は user メッセージ単位で切ることで保つ。
 MAX_CONVERSATION_TURNS = 10
-
-
-def _truncate_messages_by_turns(messages: list[ChatMessage]) -> list[ChatMessage]:
-	if MAX_CONVERSATION_TURNS <= 0 or not messages:
-		return messages
-	user_indices = [i for i, m in enumerate(messages) if m.role == 'user']
-	if len(user_indices) <= MAX_CONVERSATION_TURNS:
-		return messages
-	cut_at = user_indices[-MAX_CONVERSATION_TURNS]
-	return messages[cut_at:]
 
 
 class ChatWithPaperUseCase:
@@ -106,9 +93,6 @@ class ChatWithPaperUseCase:
 				repo = uow.chat_thread_repository
 				if thread_id:
 					thread = await repo.find_by_id(thread_id)
-					# 他ユーザーのスレッド存在を漏らさないため、所有者違いも 404 と同じ扱い。
-					if thread.user_id != user_id:
-						raise ChatThreadNotFoundError(str(thread_id))
 				else:
 					thread = await repo.create(paper_id, user_id)
 
@@ -122,7 +106,13 @@ class ChatWithPaperUseCase:
 				for _ in range(MAX_TOOL_ROUNDS):
 					tool_calls: list[ToolCallItem] = []
 					text_buffer = []
-					context = _truncate_messages_by_turns(thread.messages)
+					user_indices = [i for i, m in enumerate(thread.messages) if m.role == 'user']
+					cut_at = (
+						user_indices[-MAX_CONVERSATION_TURNS]
+						if len(user_indices) > MAX_CONVERSATION_TURNS
+						else 0
+					)
+					context = thread.messages[cut_at:]
 					async for chunk in self._llm.stream(context, RAG_TOOLS, SYSTEM_PROMPT):
 						if isinstance(chunk, list):
 							tool_calls = chunk
@@ -174,7 +164,13 @@ class ChatWithPaperUseCase:
 				else:
 					yield BlockStartEvent(index=block_index, block=TextBlock())
 					accumulated = ''
-					context = _truncate_messages_by_turns(thread.messages)
+					user_indices = [i for i, m in enumerate(thread.messages) if m.role == 'user']
+					cut_at = (
+						user_indices[-MAX_CONVERSATION_TURNS]
+						if len(user_indices) > MAX_CONVERSATION_TURNS
+						else 0
+					)
+					context = thread.messages[cut_at:]
 					async for chunk in self._llm.stream(context, [], SYSTEM_PROMPT):
 						if isinstance(chunk, list):
 							continue


### PR DESCRIPTION
## Summary
This PR refactors the message truncation logic in the chat use case by inlining the `_truncate_messages_by_turns` function and removes the user ownership validation check for chat threads.

## Key Changes
- **Removed function**: Deleted the `_truncate_messages_by_turns` helper function that was used to limit conversation history to the most recent N user turns
- **Removed import**: Deleted unused `ChatThreadNotFoundError` import
- **Inlined logic**: Replaced two function calls with inline message truncation logic that:
  - Finds all user message indices in the conversation
  - Calculates the cut-off point based on `MAX_CONVERSATION_TURNS`
  - Returns messages from the cut-off point onwards
- **Removed validation**: Deleted the user ownership check that prevented users from accessing chat threads they don't own (previously raised `ChatThreadNotFoundError` for ownership mismatches)
- **Removed comment**: Deleted explanatory comment about maintaining tool_call/tool_result correspondence

## Implementation Details
The inlined truncation logic is now duplicated in two locations within the `execute` method where message context is prepared before calling the LLM. The logic remains functionally equivalent to the original implementation, calculating the same cut-off point for conversation history.

The removal of the user ownership check may have security implications and should be reviewed carefully to ensure proper access control is maintained elsewhere in the system.

https://claude.ai/code/session_01E3MzpNEN6xANwPsorEcMpr