### PR TITLE
Enable Row Level Security for alembic_version table

### DIFF
--- a/backend/alembic/versions/c7f2a9d4b8e1_enable_rls_for_alembic_version.py
+++ b/backend/alembic/versions/c7f2a9d4b8e1_enable_rls_for_alembic_version.py
@@ -1,0 +1,29 @@
+"""enable_rls_for_alembic_version
+
+Revision ID: c7f2a9d4b8e1
+Revises: 3b1e9f4d2a7c
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7f2a9d4b8e1'
+down_revision: Union[str, Sequence[str], None] = '3b1e9f4d2a7c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ALEMBIC_VERSION_TABLE = 'alembic_version'
+
+
+def upgrade() -> None:
+	op.enable_rls(ALEMBIC_VERSION_TABLE)
+
+
+def downgrade() -> None:
+	op.disable_rls(ALEMBIC_VERSION_TABLE)


### PR DESCRIPTION
## Summary
This migration enables Row Level Security (RLS) on the `alembic_version` table to enhance security by restricting access to version records based on defined policies.

## Changes
- Added new Alembic migration (`c7f2a9d4b8e1`) that enables RLS on the `alembic_version` table
- The migration includes both upgrade and downgrade functions to maintain reversibility
- RLS can be disabled by reverting this migration if needed

## Implementation Details
- Migration revises from `3b1e9f4d2a7c`
- Uses Alembic's `op.enable_rls()` and `op.disable_rls()` operations for managing RLS state
- The `alembic_version` table name is defined as a constant for maintainability

https://claude.ai/code/session_01EhJND4QiLhZcPX9HmM61xb