### PR TITLE
ci: add Slack notifications to CI workflows

### DIFF
--- a/.github/workflows/backend-check.yml
+++ b/.github/workflows/backend-check.yml
@@ -38,3 +38,33 @@ jobs:
             exit 1
           fi
           echo "OpenAPI schema is up to date"
+
+      - name: Notify Slack on success
+        if: success()
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Backend Check passed"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":white_check_mark: *Backend Check 通過*\nBranch: `${{ github.head_ref || github.ref_name }}` by ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|実行ログ>"
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Backend Check failed"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":x: *Backend Check 失敗*\nBranch: `${{ github.head_ref || github.ref_name }}` by ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|失敗ログを確認>"

--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -33,3 +33,33 @@ jobs:
         run: npm run lint
       - name: Run formatting checks
         run: npm run format:check
+
+      - name: Notify Slack on success
+        if: success()
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Frontend Check passed"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":white_check_mark: *Frontend Check 通過*\nBranch: `${{ github.head_ref || github.ref_name }}` by ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|実行ログ>"
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Frontend Check failed"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":x: *Frontend Check 失敗*\nBranch: `${{ github.head_ref || github.ref_name }}` by ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|失敗ログを確認>"


### PR DESCRIPTION
## Summary

- Backend Check / Frontend Check ワークフローの完了時にSlackへ通知を送信するステップを追加

## 変更内容

`slackapi/slack-github-action@v2` を使用し、`chat.postMessage` でBot tokenによる通知を実装。

- **成功時** ✅ チェック名・ブランチ・実行者・ログリンクをSlackに送信
- **失敗時** ❌ 同上（失敗ログへの直リンク付き）

## 事前に必要なGitHub Secrets設定

| Secret名 | 値 |
|---|---|
| `SLACK_BOT_TOKEN` | Slack Bot User OAuth Token（`xoxb-...`） |
| `SLACK_CHANNEL_ID` | 通知先チャンネルID |

Slack AppにはBot scopeとして `chat:write` が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)