### PR TITLE
Add dialog component and image zoom functionality

### DIFF
--- a/frontend/app/components/markdown-with-math.tsx
+++ b/frontend/app/components/markdown-with-math.tsx
@@ -5,9 +5,62 @@ import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog'
 import { cn } from '~/lib/utils'
 
 import 'katex/dist/katex.min.css'
+
+function ZoomableImage({
+  alt,
+  className,
+  ...props
+}: ComponentProps<'img'>) {
+  const altText = alt ?? ''
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <img
+          {...props}
+          alt={altText}
+          loading="eager"
+          decoding="async"
+          className={cn(
+            'my-2 max-h-[min(28rem,70vh)] w-auto max-w-full cursor-zoom-in rounded-md object-contain transition-opacity hover:opacity-90',
+            className,
+          )}
+        />
+      </DialogTrigger>
+      <DialogContent
+        className="max-h-[95vh] w-auto max-w-[95vw] border-none bg-transparent p-0 shadow-none sm:max-w-[95vw]"
+        showCloseButton
+      >
+        <DialogTitle className="sr-only">
+          {altText || '画像のプレビュー'}
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          {altText || '画像の拡大表示'}
+        </DialogDescription>
+        <img
+          {...props}
+          alt={altText}
+          className="mx-auto max-h-[90vh] max-w-full rounded-md object-contain"
+        />
+        {altText && (
+          <p className="mt-2 text-center text-sm text-white/90 drop-shadow">
+            {altText}
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 const markdownComponents: NonNullable<
   ComponentProps<typeof ReactMarkdown>['components']
@@ -25,20 +78,9 @@ const markdownComponents: NonNullable<
   td: ({ children }) => (
     <td className="border border-border px-2 py-1">{children}</td>
   ),
-  img: ({ alt, className, ...props }) => {
-    return (
-      <img
-        {...props}
-        alt={alt ?? ''}
-        loading="eager"
-        decoding="async"
-        className={cn(
-          'my-2 max-h-[min(28rem,70vh)] w-auto max-w-full rounded-md object-contain',
-          className,
-        )}
-      />
-    )
-  },
+  img: ({ alt, className, ...props }) => (
+    <ZoomableImage {...props} alt={alt} className={className} />
+  ),
 }
 
 type MarkdownWithMathProps = {

--- a/frontend/app/components/markdown-with-math.tsx
+++ b/frontend/app/components/markdown-with-math.tsx
@@ -16,11 +16,7 @@ import { cn } from '~/lib/utils'
 
 import 'katex/dist/katex.min.css'
 
-function ZoomableImage({
-  alt,
-  className,
-  ...props
-}: ComponentProps<'img'>) {
+function ZoomableImage({ alt, className, ...props }: ComponentProps<'img'>) {
   const altText = alt ?? ''
 
   return (

--- a/frontend/app/components/markdown-with-math.tsx
+++ b/frontend/app/components/markdown-with-math.tsx
@@ -22,16 +22,22 @@ function ZoomableImage({ alt, className, ...props }: ComponentProps<'img'>) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <img
-          {...props}
-          alt={altText}
-          loading="eager"
-          decoding="async"
-          className={cn(
-            'my-2 max-h-[min(28rem,70vh)] w-auto max-w-full cursor-zoom-in rounded-md object-contain transition-opacity hover:opacity-90',
-            className,
-          )}
-        />
+        <button
+          type="button"
+          aria-label={altText ? `${altText}を拡大表示` : '画像を拡大表示'}
+          className="my-2 inline-block cursor-zoom-in rounded-md bg-transparent p-0 transition-opacity hover:opacity-90 focus-visible:opacity-90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
+          <img
+            {...props}
+            alt={altText}
+            loading="eager"
+            decoding="async"
+            className={cn(
+              'max-h-[min(28rem,70vh)] w-auto max-w-full rounded-md object-contain',
+              className,
+            )}
+          />
+        </button>
       </DialogTrigger>
       <DialogContent
         className="max-h-[95vh] w-auto max-w-[95vw] border-none bg-transparent p-0 shadow-none sm:max-w-[95vw]"

--- a/frontend/app/components/ui/dialog.tsx
+++ b/frontend/app/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import * as React from 'react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+import { XIcon } from 'lucide-react'
+
+import { cn } from '~/lib/utils'
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-black/70 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+          >
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
## Summary
This PR introduces a reusable Dialog component built on Radix UI primitives and implements image zoom functionality in the markdown renderer, allowing users to click images to view them in a fullscreen modal.

## Key Changes
- **New Dialog Component** (`frontend/app/components/ui/dialog.tsx`):
  - Created a comprehensive dialog component library with Radix UI primitives
  - Includes Dialog, DialogTrigger, DialogPortal, DialogOverlay, DialogContent, DialogClose, DialogHeader, DialogFooter, DialogTitle, and DialogDescription subcomponents
  - Features smooth animations for open/close states with fade and zoom effects
  - Includes optional close button with accessible keyboard navigation
  - Fully typed with TypeScript and supports custom className overrides

- **Image Zoom Feature** (`frontend/app/components/markdown-with-math.tsx`):
  - Created `ZoomableImage` component that wraps images with dialog-based zoom functionality
  - Images now display with a `cursor-zoom-in` pointer and hover opacity effect
  - Clicking an image opens a fullscreen modal preview with the full-resolution image
  - Modal displays image alt text as both a screen-reader title and visual caption
  - Integrated into markdown renderer's image component handler
  - Modal styling optimized for images with transparent background and no border

## Implementation Details
- Dialog component uses `data-slot` attributes for consistent styling hooks
- Image zoom modal uses `max-h-[90vh]` and `max-w-full` constraints to fit various screen sizes
- Alt text is displayed as both accessible metadata (sr-only) and visual caption when available
- Close button is customizable via `showCloseButton` prop on DialogContent

https://claude.ai/code/session_01A4fLZw3kLoAkxerXBmct5q