### PR TITLE
feat(blog): zoom blog body images in modal on click

### DIFF
--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -1,8 +1,14 @@
 import markdownToHtml from 'zenn-markdown-html'
 import { BookOpenIcon } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 import { BlogPaperChat } from '~/components/blog-paper-chat'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '~/components/ui/dialog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import {
   ResizableHandle,
@@ -52,10 +58,68 @@ export function meta({ loaderData }: Route.MetaArgs) {
 
 export default function BlogPage({ loaderData }: Route.ComponentProps) {
   const { paperId } = useParams()
+  const contentRef = useRef<HTMLDivElement>(null)
+  const [zoomedImage, setZoomedImage] = useState<{
+    src: string
+    alt: string
+  } | null>(null)
 
   useEffect(() => {
     import('zenn-embed-elements')
   }, [])
+
+  useEffect(() => {
+    const root = contentRef.current
+    if (!root) return
+
+    const images = Array.from(root.querySelectorAll('img'))
+    const cleanups: Array<() => void> = []
+
+    images.forEach(img => {
+      img.style.cursor = 'zoom-in'
+      img.setAttribute('role', 'button')
+      img.setAttribute('tabindex', '0')
+      if (!img.getAttribute('aria-label')) {
+        img.setAttribute(
+          'aria-label',
+          img.alt ? `${img.alt}を拡大表示` : '画像を拡大表示',
+        )
+      }
+
+      const open = () => {
+        setZoomedImage({
+          src: img.currentSrc || img.src,
+          alt: img.alt ?? '',
+        })
+      }
+
+      const onClick = (event: MouseEvent) => {
+        const anchor = (event.target as HTMLElement).closest('a')
+        if (anchor && root.contains(anchor)) {
+          event.preventDefault()
+        }
+        open()
+      }
+
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          open()
+        }
+      }
+
+      img.addEventListener('click', onClick)
+      img.addEventListener('keydown', onKeyDown)
+      cleanups.push(() => {
+        img.removeEventListener('click', onClick)
+        img.removeEventListener('keydown', onKeyDown)
+      })
+    })
+
+    return () => {
+      cleanups.forEach(fn => fn())
+    }
+  }, [loaderData.contentHtml])
 
   return (
     <div className="h-screen overflow-hidden">
@@ -100,6 +164,7 @@ export default function BlogPage({ loaderData }: Route.ComponentProps) {
                   )}
 
                   <div
+                    ref={contentRef}
                     className="znc"
                     dangerouslySetInnerHTML={{ __html: loaderData.contentHtml }}
                   />
@@ -132,6 +197,36 @@ export default function BlogPage({ loaderData }: Route.ComponentProps) {
           {paperId ? <BlogPaperChat paperId={paperId} /> : null}
         </ResizablePanel>
       </ResizablePanelGroup>
+
+      <Dialog
+        open={!!zoomedImage}
+        onOpenChange={open => {
+          if (!open) setZoomedImage(null)
+        }}
+      >
+        <DialogContent className="max-h-[95vh] w-auto max-w-[95vw] border-none bg-transparent p-0 shadow-none sm:max-w-[95vw]">
+          <DialogTitle className="sr-only">
+            {zoomedImage?.alt || '画像のプレビュー'}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            {zoomedImage?.alt || '画像の拡大表示'}
+          </DialogDescription>
+          {zoomedImage && (
+            <>
+              <img
+                src={zoomedImage.src}
+                alt={zoomedImage.alt}
+                className="mx-auto max-h-[90vh] max-w-full rounded-md object-contain"
+              />
+              {zoomedImage.alt && (
+                <p className="mt-2 text-center text-sm text-white/90 drop-shadow">
+                  {zoomedImage.alt}
+                </p>
+              )}
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- ブログ本文（`blog.$paperId.tsx`）に埋め込まれた画像をクリックするとモーダルで拡大表示できるようにした
- ブログ本文は `zenn-markdown-html` で生成した HTML を `dangerouslySetInnerHTML` で挿入しているため、React コンポーネントでラップする方式が使えなかった。代わりに `.znc` コンテナへ `ref` を取り、レンダー後に内部の `<img>` を `querySelectorAll` で拾ってクリック/キーボードハンドラを後付けする実装に変更
- キーボード操作（Tab → Enter / Space）にも対応し、`role="button"` / `tabindex="0"` / `aria-label`（alt 含む）を付与してアクセシビリティを担保
- 画像が `<a>` でラップされている場合（zenn の挙動）はリンク遷移を `preventDefault` してダイアログを開く
- 既存の `Dialog` コンポーネントを再利用し、最大 90vh / 95vw で表示。alt があればキャプションとして表示

#65 / #68 では `MarkdownWithMath`（チャット側の Markdown レンダラー）にしか修正が入っておらず、ブログ本文では効いていなかった問題のフォロー対応です。

## Test plan

- [ ] ブログ詳細ページで本文中の画像をクリック → モーダルで拡大表示される
- [ ] 画像にフォーカスを当てて Enter / Space → モーダルが開く
- [ ] ESC / オーバーレイクリック / ✕ ボタンで閉じられる
- [ ] alt 文字列がある画像は、モーダル下にキャプション表示される
- [ ] 画像が `<a>` でラップされていてもリンク遷移せずモーダルが開く
- [ ] チャット側の画像クリック（既存の `MarkdownWithMath` 経由）が引き続き動作する

https://claude.ai/code/session_01A4fLZw3kLoAkxerXBmct5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4fLZw3kLoAkxerXBmct5q)_