### PR TITLE
Improve chat UI styling and UX with semantic tokens

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -62,6 +62,14 @@ body {
   --color-hero-accent-secondary-soft: var(--secondary);
   --color-hero-card: var(--card);
   --color-hero-card-border: var(--border);
+  /* Chat semantic tokens (resolve to brand tokens above) */
+  --color-chat-user-surface: var(--chat-user-surface);
+  --color-chat-user-foreground: var(--chat-user-foreground);
+  --color-chat-assistant-surface: var(--chat-assistant-surface);
+  --color-chat-assistant-foreground: var(--chat-assistant-foreground);
+  --color-chat-assistant-border: var(--chat-assistant-border);
+  --color-chat-composer-surface: var(--chat-composer-surface);
+  --color-chat-composer-border: var(--chat-composer-border);
 }
 
 :root {
@@ -97,6 +105,14 @@ body {
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  /* Chat brand → semantic mapping (light) */
+  --chat-user-surface: var(--primary);
+  --chat-user-foreground: var(--primary-foreground);
+  --chat-assistant-surface: oklch(0.985 0 0);
+  --chat-assistant-foreground: var(--foreground);
+  --chat-assistant-border: oklch(0.922 0 0);
+  --chat-composer-surface: oklch(0.99 0 0);
+  --chat-composer-border: oklch(0.9 0 0);
 }
 
 .dark {
@@ -131,6 +147,14 @@ body {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  /* Chat brand → semantic mapping (dark) */
+  --chat-user-surface: oklch(0.6 0.13 240);
+  --chat-user-foreground: oklch(0.985 0 0);
+  --chat-assistant-surface: oklch(0.225 0 0);
+  --chat-assistant-foreground: var(--foreground);
+  --chat-assistant-border: oklch(1 0 0 / 8%);
+  --chat-composer-surface: oklch(0.205 0 0);
+  --chat-composer-border: oklch(1 0 0 / 12%);
 }
 
 @layer base {

--- a/frontend/app/components/blog-paper-chat.tsx
+++ b/frontend/app/components/blog-paper-chat.tsx
@@ -9,6 +9,7 @@ import {
   MessageSquareIcon,
   PlusIcon,
   SearchIcon,
+  SquareIcon,
   Trash2Icon,
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -53,23 +54,27 @@ const dateFormatter = new Intl.DateTimeFormat('ja-JP', { dateStyle: 'short' })
 function ChatComposer(props: {
   value: string
   onChange: (v: string) => void
+  busy: boolean
   disabled: boolean
   onSubmit: () => void
 }) {
-  const { value, onChange, disabled, onSubmit } = props
+  const { value, onChange, busy, disabled, onSubmit } = props
+  const canSubmit = !busy && !disabled && value.trim().length > 0
 
   return (
     <form
       className="pointer-events-auto mx-3 mb-3 mt-1"
       onSubmit={e => {
         e.preventDefault()
+        if (!canSubmit) return
         onSubmit()
       }}
     >
       <div
         className={cn(
-          'flex min-w-0 items-end gap-1.5 rounded-2xl border border-border/70 bg-muted/60 px-2 py-1.5',
-          'shadow-md backdrop-blur-sm dark:bg-muted/40',
+          'flex min-w-0 items-end gap-1.5 rounded-2xl border border-chat-composer-border bg-chat-composer-surface px-2 py-1.5',
+          'shadow-sm backdrop-blur-sm transition-shadow',
+          'focus-within:border-ring/60 focus-within:shadow-md',
         )}
       >
         <Textarea
@@ -81,27 +86,33 @@ function ChatComposer(props: {
           aria-label="チャット入力（⌘+Enter または Ctrl+Enter で送信）"
           title="⌘+Enter（Windows は Ctrl+Enter）で送信"
           className={cn(
-            'min-h-10 min-w-0 flex-1 resize-none text-sm leading-relaxed',
+            'min-h-10 min-w-0 flex-1 resize-none text-[15px] leading-6 text-foreground placeholder:text-muted-foreground/80',
             'border-0 bg-transparent shadow-none',
             'outline-none focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none',
-            'max-h-36 py-2',
+            'max-h-40 py-2',
           )}
           onKeyDown={e => {
             if (e.key !== 'Enter') return
             if (!e.metaKey && !e.ctrlKey) return
             if (e.nativeEvent.isComposing) return
             e.preventDefault()
+            if (!canSubmit) return
             onSubmit()
           }}
         />
         <Button
           type="submit"
           size="icon"
-          disabled={disabled || !value.trim()}
+          disabled={!canSubmit}
           className="size-9 shrink-0 rounded-full"
-          aria-label="送信"
+          aria-label={busy ? '生成中' : '送信'}
+          title={busy ? '生成中…' : '送信 (⌘+Enter)'}
         >
-          <ArrowUpIcon className="size-4" strokeWidth={2.25} />
+          {busy ? (
+            <SquareIcon className="size-3.5 fill-current" strokeWidth={0} />
+          ) : (
+            <ArrowUpIcon className="size-4" strokeWidth={2.25} />
+          )}
         </Button>
       </div>
     </form>
@@ -227,7 +238,12 @@ function AssistantMessage({
 }) {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[85%] rounded-lg bg-muted px-3 py-2 text-sm text-foreground">
+      <div
+        className={cn(
+          'max-w-[88%] rounded-2xl border border-chat-assistant-border bg-chat-assistant-surface text-chat-assistant-foreground',
+          'px-4 py-3 text-[15px] leading-7 shadow-[0_1px_2px_rgb(0_0_0/0.02)]',
+        )}
+      >
         {message.content.map((block, i) => {
           if (block.type === 'text') {
             return (
@@ -270,7 +286,12 @@ function UserMessage({ message }: { message: PaperChatMessage }) {
   if (textBlocks.length === 0) return null
   return (
     <div className="flex justify-end">
-      <div className="max-w-[85%] rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground">
+      <div
+        className={cn(
+          'max-w-[80%] rounded-2xl bg-chat-user-surface text-chat-user-foreground',
+          'px-4 py-2.5 text-[15px] leading-6 shadow-sm',
+        )}
+      >
         {textBlocks.map((block, i) => (
           <MarkdownWithMath key={i} variant="primary">
             {block.text}
@@ -519,18 +540,18 @@ function ChatView(props: {
       )}
 
       <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-3 px-4 py-4">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-6">
           {isLoading ? (
-            <div className="space-y-3">
+            <div className="space-y-5">
               <div className="flex justify-end">
-                <Skeleton className="h-12 w-2/3 rounded-lg" />
+                <Skeleton className="h-14 w-2/3 rounded-2xl" />
               </div>
               <div className="flex justify-start">
-                <Skeleton className="h-12 w-2/3 rounded-lg" />
+                <Skeleton className="h-20 w-3/4 rounded-2xl" />
               </div>
             </div>
           ) : messages.length === 0 && !busy ? (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-[15px] leading-7 text-muted-foreground">
               論文の内容について質問してください。
             </p>
           ) : (
@@ -549,8 +570,8 @@ function ChatView(props: {
 
           {isSubmitted && (
             <div className="flex justify-start">
-              <div className="flex items-center gap-1.5 rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
-                <Loader2Icon className="size-3 animate-spin" />
+              <div className="flex items-center gap-2 rounded-2xl border border-chat-assistant-border bg-chat-assistant-surface px-4 py-2.5 text-sm text-muted-foreground">
+                <Loader2Icon className="size-3.5 animate-spin" />
                 考え中…
               </div>
             </div>
@@ -561,12 +582,15 @@ function ChatView(props: {
       </ScrollArea>
 
       <div className="shrink-0 border-t border-border/40 bg-background/95 backdrop-blur-md">
-        <ChatComposer
-          value={input}
-          onChange={setInput}
-          disabled={busy || error?.code === 'chat_limit_exceeded'}
-          onSubmit={submitChat}
-        />
+        <div className="mx-auto w-full max-w-3xl">
+          <ChatComposer
+            value={input}
+            onChange={setInput}
+            busy={busy}
+            disabled={error?.code === 'chat_limit_exceeded'}
+            onSubmit={submitChat}
+          />
+        </div>
       </div>
     </>
   )

--- a/frontend/app/components/markdown-with-math.tsx
+++ b/frontend/app/components/markdown-with-math.tsx
@@ -100,8 +100,12 @@ export function MarkdownWithMath({
   return (
     <div
       className={cn(
-        'prose prose-sm max-w-none break-words leading-relaxed dark:prose-invert',
-        '[&_p:not(:last-child)]:mb-3 [&_li]:my-0.5 [&_ul]:my-2 [&_ol]:my-2',
+        'prose prose-sm max-w-none break-words dark:prose-invert',
+        // Tighten prose defaults for chat: 15px base, comfortable 1.7 line-height
+        '[&_p]:text-[15px] [&_p]:leading-7 [&_li]:text-[15px] [&_li]:leading-7',
+        '[&_p:not(:last-child)]:mb-3 [&_li]:my-1 [&_ul]:my-3 [&_ol]:my-3',
+        '[&_code]:text-[13.5px] [&_pre]:text-[13px] [&_pre]:leading-6',
+        '[&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:mt-4 [&_h2]:mb-2 [&_h3]:mt-3 [&_h3]:mb-1.5',
         variant === 'default' && 'text-foreground',
         variant === 'primary' && [
           'prose-invert text-primary-foreground',

--- a/frontend/app/components/markdown-with-math.tsx
+++ b/frontend/app/components/markdown-with-math.tsx
@@ -88,7 +88,7 @@ const markdownComponents: NonNullable<
 type MarkdownWithMathProps = {
   children: string
   className?: string
-  /** ユーザー吹き出し（primary 背景）用の KaTeX 色 */
+  /** ユーザー吹き出し（chat-user-surface 背景）用の文字・KaTeX 色 */
   variant?: 'default' | 'primary'
 }
 
@@ -108,8 +108,8 @@ export function MarkdownWithMath({
         '[&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:mt-4 [&_h2]:mb-2 [&_h3]:mt-3 [&_h3]:mb-1.5',
         variant === 'default' && 'text-foreground',
         variant === 'primary' && [
-          'prose-invert text-primary-foreground',
-          '[&_.katex]:text-primary-foreground',
+          'prose-invert text-chat-user-foreground',
+          '[&_.katex]:text-chat-user-foreground',
         ],
         className,
       )}


### PR DESCRIPTION
## Summary
Enhanced the chat interface with improved visual styling, better semantic color tokens, and improved user experience. This includes refined message bubble styling, better visual feedback during message generation, and improved typography consistency.

## Key Changes

### Chat Component Styling
- Updated `ChatComposer` to use semantic color tokens (`chat-composer-surface`, `chat-composer-border`) instead of generic utility classes
- Improved message bubble styling for both user and assistant messages with rounded corners (2xl), borders, and shadows
- Added focus-within states and transitions to the composer for better visual feedback
- Increased max-height of composer textarea from 36 to 40 units

### User Experience Improvements
- Added `busy` prop to `ChatComposer` to properly track generation state
- Updated submit button to show a loading indicator (square icon) when busy instead of the send arrow
- Improved button disabled state logic to prevent submission when busy or input is empty
- Enhanced aria-labels and titles to reflect busy state ("生成中" when generating)
- Added keyboard shortcut validation to prevent submission during generation

### Visual Refinements
- Updated typography: increased base font size to 15px with improved line-height (6-7) for better readability
- Refined message spacing and layout with max-width constraints (80-88%) and improved padding
- Updated skeleton loaders to match new message bubble styling (rounded-2xl)
- Improved "thinking" indicator styling with updated colors and sizing
- Centered chat content with max-width constraint (3xl) for better layout on wide screens

### Semantic Color Tokens
- Added new CSS custom properties for chat-specific colors in both light and dark modes:
  - `--chat-user-surface` / `--chat-user-foreground`
  - `--chat-assistant-surface` / `--chat-assistant-foreground` / `--chat-assistant-border`
  - `--chat-composer-surface` / `--chat-composer-border`
- Light mode: Uses primary color for user messages, light backgrounds for assistant
- Dark mode: Uses blue-tinted surface for user messages, dark backgrounds for assistant

### Markdown Rendering
- Tightened prose defaults for chat context with consistent 15px font size and 1.7 line-height
- Improved code block styling with smaller font sizes (13-13.5px)
- Better heading spacing and list item margins for chat messages

## Notable Implementation Details
- The `busy` state is now properly separated from the `disabled` state, allowing the UI to show generation feedback independently
- Composer validation (`canSubmit`) is checked in both form submission and keyboard event handlers
- Chat layout now uses a centered max-width container for better readability on large screens
- All color tokens follow a semantic naming pattern for easier theme customization

https://claude.ai/code/session_01Js5JDZzqH9q6VQYTtjnPGx