### PR TITLE
feat: arXiv ID入力にzodバリデーションを追加

### DIFF
--- a/frontend/app/components/ui/button.tsx
+++ b/frontend/app/components/ui/button.tsx
@@ -1,54 +1,54 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
 
-import { cn } from "~/lib/utils"
+import { cn } from '~/lib/utils'
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
+  },
 )
 
 function Button({
   className,
-  variant = "default",
-  size = "default",
+  variant = 'default',
+  size = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : 'button'
 
   return (
     <Comp

--- a/frontend/app/components/ui/button.tsx
+++ b/frontend/app/components/ui/button.tsx
@@ -1,54 +1,54 @@
-import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { Slot } from 'radix-ui'
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
 
-import { cn } from '~/lib/utils'
+import { cn } from "~/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline',
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
-        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        'icon-sm': 'size-8',
-        'icon-lg': 'size-10',
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: "default",
+      size: "default",
     },
-  },
+  }
 )
 
 function Button({
   className,
-  variant = 'default',
-  size = 'default',
+  variant = "default",
+  size = "default",
   asChild = false,
   ...props
-}: React.ComponentProps<'button'> &
+}: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {
-  const Comp = asChild ? Slot.Root : 'button'
+  const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp

--- a/frontend/app/components/ui/form.tsx
+++ b/frontend/app/components/ui/form.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+import type { Label as LabelPrimitive } from "radix-ui"
+import { Slot } from "radix-ui"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "~/lib/utils"
+import { Label } from "~/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot.Root
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-sm text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/frontend/app/components/ui/form.tsx
+++ b/frontend/app/components/ui/form.tsx
@@ -1,8 +1,8 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import type { Label as LabelPrimitive } from "radix-ui"
-import { Slot } from "radix-ui"
+import * as React from 'react'
+import type { Label as LabelPrimitive } from 'radix-ui'
+import { Slot } from 'radix-ui'
 import {
   Controller,
   FormProvider,
@@ -11,10 +11,10 @@ import {
   type ControllerProps,
   type FieldPath,
   type FieldValues,
-} from "react-hook-form"
+} from 'react-hook-form'
 
-import { cn } from "~/lib/utils"
-import { Label } from "~/components/ui/label"
+import { cn } from '~/lib/utils'
+import { Label } from '~/components/ui/label'
 
 const Form = FormProvider
 
@@ -26,7 +26,7 @@ type FormFieldContextValue<
 }
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
+  {} as FormFieldContextValue,
 )
 
 const FormField = <
@@ -50,7 +50,7 @@ const useFormField = () => {
   const fieldState = getFieldState(fieldContext.name, formState)
 
   if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
+    throw new Error('useFormField should be used within <FormField>')
   }
 
   const { id } = itemContext
@@ -70,17 +70,17 @@ type FormItemContextValue = {
 }
 
 const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
+  {} as FormItemContextValue,
 )
 
-function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   const id = React.useId()
 
   return (
     <FormItemContext.Provider value={{ id }}>
       <div
         data-slot="form-item"
-        className={cn("grid gap-2", className)}
+        className={cn('grid gap-2', className)}
         {...props}
       />
     </FormItemContext.Provider>
@@ -97,7 +97,7 @@ function FormLabel({
     <Label
       data-slot="form-label"
       data-error={!!error}
-      className={cn("data-[error=true]:text-destructive", className)}
+      className={cn('data-[error=true]:text-destructive', className)}
       htmlFor={formItemId}
       {...props}
     />
@@ -122,22 +122,22 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
   )
 }
 
-function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
   const { formDescriptionId } = useFormField()
 
   return (
     <p
       data-slot="form-description"
       id={formDescriptionId}
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
 }
 
-function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message ?? "") : props.children
+  const body = error ? String(error?.message ?? '') : props.children
 
   if (!body) {
     return null
@@ -147,7 +147,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-sm text-destructive", className)}
+      className={cn('text-sm text-destructive', className)}
       {...props}
     >
       {body}

--- a/frontend/app/components/ui/label.tsx
+++ b/frontend/app/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "~/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/frontend/app/components/ui/label.tsx
+++ b/frontend/app/components/ui/label.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import * as React from 'react'
+import { Label as LabelPrimitive } from 'radix-ui'
 
-import { cn } from "~/lib/utils"
+import { cn } from '~/lib/utils'
 
 function Label({
   className,
@@ -11,8 +11,8 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className,
       )}
       {...props}
     />

--- a/frontend/app/routes/arxiv.tsx
+++ b/frontend/app/routes/arxiv.tsx
@@ -20,7 +20,10 @@ const arxivIdSchema = z.object({
   paperId: z
     .string()
     .trim()
-    .regex(/^\d{4}\.\d{4,5}(v\d+)?$/, '有効なarXiv IDを入力してください（例: 2301.00001）'),
+    .regex(
+      /^\d{4}\.\d{4,5}(v\d+)?$/,
+      '有効なarXiv IDを入力してください（例: 2301.00001）',
+    ),
 })
 
 export function meta() {
@@ -110,60 +113,60 @@ export default function Arxiv() {
               )}
             />
 
-          {steps.length > 0 && (
-            <ul className="mt-4 space-y-1.5 text-sm">
-              {steps.map((step, i) => (
-                <li
-                  key={i}
-                  className={`flex items-center gap-2 transition-opacity ${step.done ? 'text-muted-foreground' : 'text-foreground'}`}
-                >
-                  {step.done ? (
-                    <span className="text-hero-accent">✓</span>
-                  ) : (
-                    <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-hero-accent border-t-transparent" />
-                  )}
-                  <span className={step.done ? 'line-through' : ''}>
-                    {step.message}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
+            {steps.length > 0 && (
+              <ul className="mt-4 space-y-1.5 text-sm">
+                {steps.map((step, i) => (
+                  <li
+                    key={i}
+                    className={`flex items-center gap-2 transition-opacity ${step.done ? 'text-muted-foreground' : 'text-foreground'}`}
+                  >
+                    {step.done ? (
+                      <span className="text-hero-accent">✓</span>
+                    ) : (
+                      <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-hero-accent border-t-transparent" />
+                    )}
+                    <span className={step.done ? 'line-through' : ''}>
+                      {step.message}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
 
-          {error === 'limit_exceeded' ? (
-            <div className="mt-3 rounded-lg border border-hero-accent/40 bg-hero-accent/10 px-4 py-3 text-sm">
-              {isAnonymous ? (
-                <span>
-                  今月の無料生成回数（3回）を使い切りました。
-                  <button
-                    type="button"
-                    onClick={signInWithGoogle}
-                    className="ml-1 font-semibold underline underline-offset-2"
-                  >
-                    Googleでログイン
-                  </button>
-                  すると月10回まで生成できます。
-                </span>
-              ) : isPaid ? (
-                <span>
-                  今月の生成回数（100回）に達しました。来月のリセットまでお待ちください。
-                </span>
-              ) : (
-                <span>
-                  今月の生成回数（10回）を使い切りました。
-                  <Link
-                    to="/pricing"
-                    className="ml-1 font-semibold underline underline-offset-2"
-                  >
-                    有料プランにアップグレード
-                  </Link>
-                  すると月100回まで生成できます。
-                </span>
-              )}
-            </div>
-          ) : error ? (
-            <p className="mt-3 text-sm text-destructive">{error}</p>
-          ) : null}
+            {error === 'limit_exceeded' ? (
+              <div className="mt-3 rounded-lg border border-hero-accent/40 bg-hero-accent/10 px-4 py-3 text-sm">
+                {isAnonymous ? (
+                  <span>
+                    今月の無料生成回数（3回）を使い切りました。
+                    <button
+                      type="button"
+                      onClick={signInWithGoogle}
+                      className="ml-1 font-semibold underline underline-offset-2"
+                    >
+                      Googleでログイン
+                    </button>
+                    すると月10回まで生成できます。
+                  </span>
+                ) : isPaid ? (
+                  <span>
+                    今月の生成回数（100回）に達しました。来月のリセットまでお待ちください。
+                  </span>
+                ) : (
+                  <span>
+                    今月の生成回数（10回）を使い切りました。
+                    <Link
+                      to="/pricing"
+                      className="ml-1 font-semibold underline underline-offset-2"
+                    >
+                      有料プランにアップグレード
+                    </Link>
+                    すると月100回まで生成できます。
+                  </span>
+                )}
+              </div>
+            ) : error ? (
+              <p className="mt-3 text-sm text-destructive">{error}</p>
+            ) : null}
           </form>
         </Form>
       </section>

--- a/frontend/app/routes/arxiv.tsx
+++ b/frontend/app/routes/arxiv.tsx
@@ -1,10 +1,27 @@
 import { useEffect } from 'react'
 import { Link, useNavigate } from 'react-router'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 
 import { useAuth } from '~/contexts/auth-context'
 import { useBlogStream } from '../hooks/use-blog-stream'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from '../components/ui/form'
+
+const arxivIdSchema = z.object({
+  paperId: z
+    .string()
+    .trim()
+    .regex(/^\d{4}\.\d{4,5}(v\d+)?$/, '有効なarXiv IDを入力してください（例: 2301.00001）'),
+})
 
 export function meta() {
   return [
@@ -21,18 +38,19 @@ export default function Arxiv() {
   const { isAnonymous, isPaid, signInWithGoogle } = useAuth()
   const { status, steps, error, paperId, startArxivStream } = useBlogStream()
 
+  const form = useForm<z.infer<typeof arxivIdSchema>>({
+    resolver: zodResolver(arxivIdSchema),
+    defaultValues: { paperId: '' },
+  })
+
   useEffect(() => {
     if (status === 'complete' && paperId) {
       navigate(`/blog/${paperId}`)
     }
   }, [status, paperId, navigate])
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const id =
-      new FormData(e.currentTarget).get('paperId')?.toString().trim() ?? ''
-    if (!id) return
-    startArxivStream(id)
+  function handleSubmit(values: z.infer<typeof arxivIdSchema>) {
+    startArxivStream(values.paperId)
   }
 
   const isStreaming = status === 'streaming'
@@ -59,26 +77,38 @@ export default function Arxiv() {
           </p>
         </div>
 
-        <form
-          onSubmit={handleSubmit}
-          className="w-full rounded-2xl border border-hero-card-border/70 bg-hero-card/80 p-5 shadow-2xl backdrop-blur-sm sm:p-6"
-        >
-          <div className="flex flex-col gap-3 sm:flex-row">
-            <Input
-              type="text"
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="w-full rounded-2xl border border-hero-card-border/70 bg-hero-card/80 p-5 shadow-2xl backdrop-blur-sm sm:p-6"
+          >
+            <FormField
+              control={form.control}
               name="paperId"
-              placeholder="arXiv ID（例: 2301.00001）"
-              disabled={isStreaming}
-              className="border-input bg-background text-foreground placeholder:text-muted-foreground sm:flex-1"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex flex-col gap-3 sm:flex-row">
+                    <FormControl>
+                      <Input
+                        type="text"
+                        placeholder="arXiv ID（例: 2301.00001）"
+                        disabled={isStreaming}
+                        className="border-input bg-background text-foreground placeholder:text-muted-foreground sm:flex-1"
+                        {...field}
+                      />
+                    </FormControl>
+                    <Button
+                      type="submit"
+                      disabled={isStreaming}
+                      className="bg-hero-accent font-semibold text-primary-foreground transition-colors hover:bg-hero-accent/90 sm:w-40"
+                    >
+                      {isStreaming ? '生成中...' : 'ブログを生成'}
+                    </Button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <Button
-              type="submit"
-              disabled={isStreaming}
-              className="bg-hero-accent font-semibold text-primary-foreground transition-colors hover:bg-hero-accent/90 sm:w-40"
-            >
-              {isStreaming ? '生成中...' : 'ブログを生成'}
-            </Button>
-          </div>
 
           {steps.length > 0 && (
             <ul className="mt-4 space-y-1.5 text-sm">
@@ -134,7 +164,8 @@ export default function Arxiv() {
           ) : error ? (
             <p className="mt-3 text-sm text-destructive">{error}</p>
           ) : null}
-        </form>
+          </form>
+        </Form>
       </section>
     </main>
   )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
         "@ai-sdk/react": "^3.0.147",
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.94.5",
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-slot": "^1.2.4",
         "@react-router/node": "^7.9.2",
         "@react-router/serve": "^7.9.2",
@@ -20,6 +21,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-hook-form": "^7.75.0",
         "react-markdown": "^10.1.0",
         "react-pdf": "^10.4.1",
         "react-resizable-panels": "^4.9.0",
@@ -32,7 +34,8 @@
         "workers-ai-provider": "^3.1.9",
         "zenn-content-css": "^0.4.7",
         "zenn-embed-elements": "^0.4.7",
-        "zenn-markdown-html": "^0.4.7"
+        "zenn-markdown-html": "^0.4.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",
@@ -1677,6 +1680,18 @@
       "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
       "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -5005,6 +5020,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
@@ -13716,6 +13737,22 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17261,11 +17298,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@ai-sdk/react": "^3.0.147",
     "@hey-api/client-fetch": "^0.13.1",
     "@hey-api/openapi-ts": "^0.94.5",
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-slot": "^1.2.4",
     "@react-router/node": "^7.9.2",
     "@react-router/serve": "^7.9.2",
@@ -35,6 +36,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-hook-form": "^7.75.0",
     "react-markdown": "^10.1.0",
     "react-pdf": "^10.4.1",
     "react-resizable-panels": "^4.9.0",
@@ -47,7 +49,8 @@
     "workers-ai-provider": "^3.1.9",
     "zenn-content-css": "^0.4.7",
     "zenn-embed-elements": "^0.4.7",
-    "zenn-markdown-html": "^0.4.7"
+    "zenn-markdown-html": "^0.4.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",


### PR DESCRIPTION
## Summary
- フロントエンドのarXiv ID入力にzod + react-hook-formによるバリデーションを追加
- バックエンドと同じ正規表現（`^\d{4}\.\d{4,5}(v\d+)?$`）でクライアント側でも形式チェック
- 不正なIDでのAPI呼び出しを防止し、即座にエラーメッセージを表示

## Changes
- `frontend/app/routes/arxiv.tsx` — zodスキーマ定義、react-hook-form + shadcn Formコンポーネントに移行
- `frontend/app/components/ui/form.tsx` — shadcn Formコンポーネント追加
- `frontend/app/components/ui/label.tsx` — shadcn Labelコンポーネント追加（Form依存）
- `frontend/package.json` — zod, react-hook-form, @hookform/resolvers を追加

## Test plan
- [ ] arXiv IDフォームに不正な値（例: `abc`, `2301.1`, `2301.123456`）を入力して送信し、エラーメッセージが表示されることを確認
- [ ] 正しいarXiv ID（例: `2301.00001`, `2301.12345v2`）を入力して送信し、ブログ生成が開始されることを確認
- [ ] ストリーミング中にInputとButtonがdisabledになることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)