### PR TITLE
fix(figures): 図面提案の検索ボタンとプロンプトテンプレートが動かない不具合を修正

### DIFF
--- a/frontend/app/hooks/use-figure-suggestion.ts
+++ b/frontend/app/hooks/use-figure-suggestion.ts
@@ -1,4 +1,4 @@
-import { useActionState } from 'react'
+import { startTransition, useActionState, useCallback } from 'react'
 
 import { suggestFiguresApiV1FiguresSuggestPost } from '~/api/sdk.gen'
 import type { FigureSuggestionItemSchema } from '~/api/types.gen'
@@ -22,23 +22,36 @@ const INITIAL_STATE: FigureSuggestState = {
  * `submit(query)` runs the search; `isPending` tracks the in-flight request.
  */
 export function useFigureSuggestion() {
-  const [state, submit, isPending] = useActionState<FigureSuggestState, string>(
-    async (_prev, query) => {
-      const { data, error } = await suggestFiguresApiV1FiguresSuggestPost({
-        body: { query, limit: 24 },
-      })
-      if (!data) {
-        return {
-          items: [],
-          error: error
-            ? '図の検索に失敗しました。しばらくしてからもう一度お試しください。'
-            : '図の検索に失敗しました。',
-          submitted: true,
-        }
+  const [state, dispatch, isPending] = useActionState<
+    FigureSuggestState,
+    string
+  >(async (_prev, query) => {
+    const { data, error } = await suggestFiguresApiV1FiguresSuggestPost({
+      body: { query, limit: 24 },
+    })
+    if (!data) {
+      return {
+        items: [],
+        error: error
+          ? '図の検索に失敗しました。しばらくしてからもう一度お試しください。'
+          : '図の検索に失敗しました。',
+        submitted: true,
       }
-      return { items: data.items, error: null, submitted: true }
+    }
+    return { items: data.items, error: null, submitted: true }
+  }, INITIAL_STATE)
+
+  // The composer dispatches from react-hook-form's async `handleSubmit`
+  // callback, which resolves outside the original event's transition. Calling
+  // the action there directly would run it outside a transition, so `isPending`
+  // never flips and React leaves the transition dangling (which also blocks
+  // later `setValue` re-renders). Wrapping the dispatch in `startTransition`
+  // gives it a transition scope no matter where `submit` is called from.
+  const submit = useCallback(
+    (query: string) => {
+      startTransition(() => dispatch(query))
     },
-    INITIAL_STATE,
+    [dispatch],
   )
 
   return {


### PR DESCRIPTION
## 概要

図面提案（Figure Inspiration）機能で報告された 2 つの不具合を修正します。

1. **検索ボタンを押しても何も始まらない** — ローディング表示も結果も出ない
2. **一度プロンプトテンプレート（例プロンプト）を入れると、別のテンプレートを押しても textarea が更新されない**

## 根本原因（両方とも同一）

`FigureSearchComposer` は react-hook-form の `form.handleSubmit(...)` 経由で送信します。これは zodResolver による**非同期バリデーション**を挟むため、実際に `onSubmit` が呼ばれるのは元のクリックイベントの同期スコープ（transition）を抜けた後（`await` 後のマイクロタスク）です。

そこで `use-figure-suggestion` の `useActionState` の dispatch を直接呼ぶと、**React の transition の外で action が実行**され、

- `isPending` が一度も `true` にならない → ローディングも結果表示も出ない（不具合 1）
- ぶら下がった transition が以降の `setValue` による再レンダリングまで阻害 → 検索後に例プロンプトを押しても textarea が更新されない（不具合 2）

React 自身も以下の警告を出していました:

> An async function with useActionState was called outside of a transition. ... isPending will not update correctly.

## 修正

`use-figure-suggestion` フックの公開 API (`submit(query)`) はそのままに、dispatch を `startTransition` で包みました。これにより呼び出し元（react-hook-form の非同期コールバック）に関係なく常に transition スコープを持たせ、両方の不具合を解消します。コンポーザ側は変更不要で、責務の分離も保てます。

## 検証

ローカルで実コンポーネント + 実フック（SDK 呼び出しのみモック）を使った再現テストを作成し、

- 修正前: `isPending` が `true` にならず、検索後に `setValue` が効かないことを再現
- 修正後: 検索でローディング → 結果表示が出る／検索後も例プロンプトで textarea が更新される

ことを確認しました（テストファイルは恒久的なテスト基盤が未整備のため本 PR には含めていません）。`npm run typecheck` / `eslint` / `prettier` も通過済みです。

https://claude.ai/code/session_01SKjHyn5KuASzwfA61RSqN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKjHyn5KuASzwfA61RSqN5)_