### PR TITLE
fix: nomic 埋め込みモデルが meta デバイスに残り /embed が 500 になる問題を修正

### DIFF
--- a/pdf_analysis/dependencies.py
+++ b/pdf_analysis/dependencies.py
@@ -32,14 +32,22 @@ def get_onnx_session() -> InferenceSession:
 def get_nomic_image_embedding_gateway() -> NomicImageEmbeddingGateway:
     # local_files_only=True: HF hub が再ダウンロードして n_inner=2048.0(float) に戻るのを防ぐ
     processor = AutoImageProcessor.from_pretrained(NOMIC_VISION_MODEL)
-    model = AutoModel.from_pretrained(NOMIC_VISION_MODEL, trust_remote_code=True)
+    # low_cpu_mem_usage=False: nomic のカスタム modeling は meta デバイス上の重みを
+    # in-place copy で読み込むため no-op になり meta のまま残る。実体化を強制する
+    model = AutoModel.from_pretrained(
+        NOMIC_VISION_MODEL, trust_remote_code=True, low_cpu_mem_usage=False
+    )
     return NomicImageEmbeddingGateway(model=model, processor=processor)
 
 
 @lru_cache
 def get_nomic_text_embedding_gateway() -> NomicTextEmbeddingGateway:
     tokenizer = AutoTokenizer.from_pretrained(NOMIC_TEXT_MODEL, trust_remote_code=True)
-    model = AutoModel.from_pretrained(NOMIC_TEXT_MODEL, trust_remote_code=True)
+    # low_cpu_mem_usage=False: nomic のカスタム modeling は meta デバイス上の重みを
+    # in-place copy で読み込むため no-op になり meta のまま残る。実体化を強制する
+    model = AutoModel.from_pretrained(
+        NOMIC_TEXT_MODEL, trust_remote_code=True, low_cpu_mem_usage=False
+    )
     return NomicTextEmbeddingGateway(model=model, tokenizer=tokenizer)
 
 


### PR DESCRIPTION
## 概要

pdf_analysis マイクロサービスの `/embed/query` が突然 500 (`RuntimeError: Tensor on device cpu is not on the expected device meta!`) を返すようになった問題を修正します。

## 原因

コンテナ再ビルドで新しい `transformers`(依存指定は `>=4.35.0,<5.0.0`)が入ったことが引き金です。

- 新しい `transformers` の `from_pretrained` は `low_cpu_mem_usage=True` を既定とし、まず **meta デバイス**上にモデルを構築してからチェックポイントの重みを読み込みます。
- nomic のカスタム remote modeling (`modeling_hf_nomic_bert.py`) は `_load_from_state_dict` を **in-place `copy_`** で実装しているため、コピー先パラメータが meta だとコピーは **no-op** になります(ログの `copying from a non-meta parameter ... to a meta parameter ..., which is a no-op` がこれ)。
- 結果としてモデルの重みが meta デバイスのまま残り、推論時に CPU 入力と device 不一致を起こして 500 になります。

## 修正

nomic のテキスト/画像埋め込みモデルの `AutoModel.from_pretrained` に `low_cpu_mem_usage=False` を指定し、実体の CPU テンソルを生成させてからチェックポイントを確実に読み込むようにしました。

```python
model = AutoModel.from_pretrained(
    NOMIC_TEXT_MODEL, trust_remote_code=True, low_cpu_mem_usage=False
)
```

BGE 側は標準 modeling のため影響なし、変更不要です。

## 確認

- `python -m py_compile dependencies.py` で構文確認済み。
- 実モデルでの動作確認(`/embed/query` が 200 を返すこと)はレビュー時にコンテナ上でお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_014FZ6Qn6EKGGc2nZxqGXDZ1)_