### PR TITLE
feat: ブログ一覧（公開アーカイブ）にキーワード検索を追加

### DIFF
--- a/backend/application/usecase/list_blog_posts.py
+++ b/backend/application/usecase/list_blog_posts.py
@@ -18,9 +18,13 @@ class ListBlogPostsUseCase:
 	def __init__(self, blog_post_repository: IBlogPostRepository):
 		self._blog_post_repository = blog_post_repository
 
-	async def execute(self, page: int, page_size: int) -> PaginatedBlogPosts:
-		items = await self._blog_post_repository.find_all(page=page, page_size=page_size)
-		total = await self._blog_post_repository.count_all()
+	async def execute(
+		self, page: int, page_size: int, keyword: str | None = None
+	) -> PaginatedBlogPosts:
+		items = await self._blog_post_repository.find_all(
+			page=page, page_size=page_size, keyword=keyword
+		)
+		total = await self._blog_post_repository.count_all(keyword=keyword)
 		total_pages = (total + page_size - 1) // page_size if page_size > 0 else 0
 		return PaginatedBlogPosts(
 			items=items,

--- a/backend/controller/blog.py
+++ b/backend/controller/blog.py
@@ -66,8 +66,11 @@ async def list_blogs(
 	list_blog_posts: Annotated[ListBlogPostsUseCase, Depends(get_list_blog_posts)],
 	page: Annotated[int, Query(ge=1, description='Page number')] = 1,
 	page_size: Annotated[int, Query(ge=1, le=100, description='Items per page')] = 10,
+	keyword: Annotated[
+		str | None, Query(description='Keyword to filter by title/summary/authors')
+	] = None,
 ) -> PaginatedBlogPostResponseSchema:
-	paginated = await list_blog_posts.execute(page=page, page_size=page_size)
+	paginated = await list_blog_posts.execute(page=page, page_size=page_size, keyword=keyword)
 	return PaginatedBlogPostResponseSchema.from_paginated(paginated)
 
 

--- a/backend/domain/repositories/i_blog_post_repository.py
+++ b/backend/domain/repositories/i_blog_post_repository.py
@@ -26,13 +26,23 @@ class IBlogPostRepository(ABC):
 		...
 
 	@abstractmethod
-	async def find_all(self, page: int, page_size: int) -> list[BlogPost]:
-		"""Find arXiv blog posts ordered by created_at descending with pagination."""
+	async def find_all(
+		self, page: int, page_size: int, keyword: str | None = None
+	) -> list[BlogPost]:
+		"""Find arXiv blog posts ordered by created_at descending with pagination.
+
+		When ``keyword`` is given, results are filtered by a case-insensitive partial
+		match against the title, summary, or authors.
+		"""
 		...
 
 	@abstractmethod
-	async def count_all(self) -> int:
-		"""Return the total number of arXiv blog posts."""
+	async def count_all(self, keyword: str | None = None) -> int:
+		"""Return the total number of arXiv blog posts.
+
+		When ``keyword`` is given, only posts matching it (title/summary/authors) are
+		counted.
+		"""
 		...
 
 	@abstractmethod

--- a/backend/infrastructure/postgres/repositories/postgres_blog_post_repository.py
+++ b/backend/infrastructure/postgres/repositories/postgres_blog_post_repository.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from logging import getLogger
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import ColumnElement, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -35,8 +35,21 @@ class PostgresBlogPostRepository(IBlogPostRepository):
 			updated_at=row.updated_at,
 		)
 
-	async def find_all(self, page: int, page_size: int) -> list[BlogPost]:
-		"""Return arXiv blog posts only (public)."""
+	def _keyword_condition(self, keyword: str | None) -> ColumnElement[bool] | None:
+		"""Build a case-insensitive partial-match filter over title/summary/authors."""
+		if keyword is None or not keyword.strip():
+			return None
+		pattern = f'%{keyword.strip()}%'
+		return or_(
+			col(BlogPostContentModel.title).ilike(pattern),
+			col(BlogPostContentModel.summary).ilike(pattern),
+			func.array_to_string(col(BlogPostContentModel.authors), ' ').ilike(pattern),
+		)
+
+	async def find_all(
+		self, page: int, page_size: int, keyword: str | None = None
+	) -> list[BlogPost]:
+		"""Return arXiv blog posts only (public), optionally filtered by keyword."""
 		offset = (page - 1) * page_size
 		statement = (
 			select(BlogPostContentModel)
@@ -45,17 +58,23 @@ class PostgresBlogPostRepository(IBlogPostRepository):
 			.offset(offset)
 			.limit(page_size)
 		)
+		condition = self._keyword_condition(keyword)
+		if condition is not None:
+			statement = statement.where(condition)
 		result = await self._session.execute(statement)
 		rows = result.scalars().all()
 		return [self._to_entity(row) for row in rows]
 
-	async def count_all(self) -> int:
-		"""Return the total number of arXiv blog posts."""
+	async def count_all(self, keyword: str | None = None) -> int:
+		"""Return the total number of arXiv blog posts, optionally filtered by keyword."""
 		statement = (
 			select(func.count())
 			.select_from(BlogPostContentModel)
 			.where(col(BlogPostContentModel.source_type) == 'arxiv')
 		)
+		condition = self._keyword_condition(keyword)
+		if condition is not None:
+			statement = statement.where(condition)
 		result = await self._session.execute(statement)
 		return result.scalar_one()
 

--- a/backend/infrastructure/postgres/repositories/postgres_blog_post_repository.py
+++ b/backend/infrastructure/postgres/repositories/postgres_blog_post_repository.py
@@ -39,11 +39,17 @@ class PostgresBlogPostRepository(IBlogPostRepository):
 		"""Build a case-insensitive partial-match filter over title/summary/authors."""
 		if keyword is None or not keyword.strip():
 			return None
-		pattern = f'%{keyword.strip()}%'
+		# Escape LIKE metacharacters so the keyword is matched literally; otherwise
+		# inputs like '%' or '_' would behave as wildcards. Escape the backslash
+		# first to avoid double-escaping.
+		escaped = keyword.strip().replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+		pattern = f'%{escaped}%'
 		return or_(
-			col(BlogPostContentModel.title).ilike(pattern),
-			col(BlogPostContentModel.summary).ilike(pattern),
-			func.array_to_string(col(BlogPostContentModel.authors), ' ').ilike(pattern),
+			col(BlogPostContentModel.title).ilike(pattern, escape='\\'),
+			col(BlogPostContentModel.summary).ilike(pattern, escape='\\'),
+			func.array_to_string(col(BlogPostContentModel.authors), ' ').ilike(
+				pattern, escape='\\'
+			),
 		)
 
 	async def find_all(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -87,6 +87,24 @@
               "title": "Page Size"
             },
             "description": "Items per page"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Keyword to filter by title/summary/authors",
+              "title": "Keyword"
+            },
+            "description": "Keyword to filter by title/summary/authors"
           }
         ],
         "responses": {

--- a/frontend/app/api/sdk.gen.ts
+++ b/frontend/app/api/sdk.gen.ts
@@ -490,6 +490,9 @@ export const stripeWebhookApiV1BillingWebhookPost = <
  * Suggest Figures
  *
  * Suggest reference figures across all papers from a free-form description.
+ *
+ * Only figures from public arXiv papers and the requester's own PDF papers are
+ * returned, mirroring the blog post visibility rules.
  */
 export const suggestFiguresApiV1FiguresSuggestPost = <
   ThrowOnError extends boolean = false,

--- a/frontend/app/api/types.gen.ts
+++ b/frontend/app/api/types.gen.ts
@@ -579,6 +579,12 @@ export type ListBlogsApiV1BlogGetData = {
      * Items per page
      */
     page_size?: number
+    /**
+     * Keyword
+     *
+     * Keyword to filter by title/summary/authors
+     */
+    keyword?: string | null
   }
   url: '/api/v1/blog/'
 }

--- a/frontend/app/components/blog/blog-list-pagination.tsx
+++ b/frontend/app/components/blog/blog-list-pagination.tsx
@@ -24,19 +24,26 @@ const DEFAULT_PAGE_SIZE = 10
 export function parsePageParams(url: URL): {
   page: number
   pageSize: number
+  keyword: string | undefined
 } {
   const page = Math.max(1, Number(url.searchParams.get('page') ?? '1'))
   const raw = Number(url.searchParams.get('page_size'))
   const pageSize = (PAGE_SIZE_OPTIONS as readonly number[]).includes(raw)
     ? raw
     : DEFAULT_PAGE_SIZE
-  return { page, pageSize }
+  const keyword = url.searchParams.get('keyword')?.trim() || undefined
+  return { page, pageSize, keyword }
 }
 
-function buildPageUrl(page: number, pageSize: number): string {
+function buildPageUrl(
+  page: number,
+  pageSize: number,
+  keyword?: string,
+): string {
   const params = new URLSearchParams()
   params.set('page', String(page))
   if (pageSize !== DEFAULT_PAGE_SIZE) params.set('page_size', String(pageSize))
+  if (keyword) params.set('keyword', keyword)
   return `?${params}`
 }
 
@@ -60,10 +67,12 @@ export function BlogListPagination({
   currentPage,
   totalPages,
   pageSize,
+  keyword,
 }: {
   currentPage: number
   totalPages: number
   pageSize: number
+  keyword?: string
 }) {
   const navigate = useNavigate()
 
@@ -77,7 +86,7 @@ export function BlogListPagination({
         <span>表示件数</span>
         <Select
           value={String(pageSize)}
-          onValueChange={v => navigate(buildPageUrl(1, Number(v)))}
+          onValueChange={v => navigate(buildPageUrl(1, Number(v), keyword))}
         >
           <SelectTrigger className="w-20">
             <SelectValue />
@@ -99,7 +108,7 @@ export function BlogListPagination({
               <PaginationPrevious
                 href={
                   currentPage > 1
-                    ? buildPageUrl(currentPage - 1, pageSize)
+                    ? buildPageUrl(currentPage - 1, pageSize, keyword)
                     : undefined
                 }
                 aria-disabled={currentPage <= 1}
@@ -116,7 +125,7 @@ export function BlogListPagination({
               ) : (
                 <PaginationItem key={page}>
                   <PaginationLink
-                    href={buildPageUrl(page, pageSize)}
+                    href={buildPageUrl(page, pageSize, keyword)}
                     isActive={page === currentPage}
                   >
                     {page}
@@ -128,7 +137,7 @@ export function BlogListPagination({
               <PaginationNext
                 href={
                   currentPage < totalPages
-                    ? buildPageUrl(currentPage + 1, pageSize)
+                    ? buildPageUrl(currentPage + 1, pageSize, keyword)
                     : undefined
                 }
                 aria-disabled={currentPage >= totalPages}

--- a/frontend/app/components/blog/blog-search-form.tsx
+++ b/frontend/app/components/blog/blog-search-form.tsx
@@ -1,61 +1,100 @@
-import { SearchIcon, XIcon } from 'lucide-react'
-import { useNavigate, useSearchParams } from 'react-router'
+import { useEffect, useRef } from 'react'
+import { LoaderCircleIcon, SearchIcon, XIcon } from 'lucide-react'
+import { Form, useNavigation, useSearchParams, useSubmit } from 'react-router'
 
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 
+// Wait a beat after the last keystroke before hitting the loader, so live
+// filtering doesn't fire a request on every character.
+const DEBOUNCE_MS = 300
+
+/**
+ * Keyword search for the public blog archive.
+ *
+ * Follows the React Router data pattern for search/filter UIs: a GET `<Form>`
+ * serialises its fields into the URL and re-runs the route loader (searching is
+ * a read, so it belongs in the loader, not an action). `useSubmit` drives
+ * debounced live filtering, and the input value stays in sync with the URL so
+ * browser back/forward keeps working.
+ */
 export function BlogSearchForm() {
   const [searchParams] = useSearchParams()
-  const navigate = useNavigate()
-  const currentKeyword = searchParams.get('keyword')?.trim() ?? ''
+  const submit = useSubmit()
+  const navigation = useNavigation()
 
-  function navigateWithKeyword(keyword: string) {
-    const params = new URLSearchParams()
-    // Preserve the page size but reset to the first page on a new search.
-    const pageSize = searchParams.get('page_size')
-    if (pageSize) params.set('page_size', pageSize)
-    if (keyword) params.set('keyword', keyword)
-    navigate(`?${params}`)
+  const keyword = searchParams.get('keyword') ?? ''
+  // Preserve the chosen page size across searches (reset to page 1 implicitly,
+  // since `page` is not part of this form).
+  const pageSize = searchParams.get('page_size') ?? ''
+
+  // A keyword navigation is in flight. For GET submissions the pending data
+  // lives in `navigation.location.search`, not `navigation.formData`.
+  const searching =
+    navigation.location != null &&
+    new URLSearchParams(navigation.location.search).has('keyword')
+
+  // Keep the uncontrolled input in sync with the URL (e.g. on back/forward).
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (inputRef.current) inputRef.current.value = keyword
+  }, [keyword])
+
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  function handleChange(event: React.FormEvent<HTMLFormElement>) {
+    const form = event.currentTarget
+    // Push a history entry for the first search, then replace it on subsequent
+    // keystrokes so the back button returns to the unfiltered list in one step.
+    const isFirstSearch = keyword === ''
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      submit(form, { replace: !isFirstSearch })
+    }, DEBOUNCE_MS)
   }
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const value = new FormData(event.currentTarget).get('keyword')
-    navigateWithKeyword(typeof value === 'string' ? value.trim() : '')
+  function handleClear() {
+    if (inputRef.current) inputRef.current.value = ''
+    clearTimeout(timerRef.current)
+    inputRef.current?.form?.requestSubmit()
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
+    <Form
+      method="get"
       role="search"
+      onChange={handleChange}
+      onSubmit={() => clearTimeout(timerRef.current)}
       className="mb-8 flex items-center gap-2"
     >
+      {pageSize && <input type="hidden" name="page_size" value={pageSize} />}
       <div className="relative flex-1">
-        <SearchIcon
-          aria-hidden
-          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-        />
+        {searching ? (
+          <LoaderCircleIcon
+            aria-hidden
+            className="absolute top-1/2 left-3 size-4 -translate-y-1/2 animate-spin text-muted-foreground"
+          />
+        ) : (
+          <SearchIcon
+            aria-hidden
+            className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+        )}
         <Input
-          key={currentKeyword}
+          ref={inputRef}
           type="search"
           name="keyword"
-          defaultValue={currentKeyword}
+          defaultValue={keyword}
           placeholder="タイトル・概要・著者で検索"
           aria-label="ブログ記事を検索"
           className="pl-9"
         />
       </div>
-      {currentKeyword && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => navigateWithKeyword('')}
-        >
+      {keyword && (
+        <Button type="button" variant="ghost" onClick={handleClear}>
           <XIcon className="size-4" />
           クリア
         </Button>
       )}
-      <Button type="submit">検索</Button>
-    </form>
+    </Form>
   )
 }

--- a/frontend/app/components/blog/blog-search-form.tsx
+++ b/frontend/app/components/blog/blog-search-form.tsx
@@ -1,100 +1,61 @@
-import { useEffect, useRef } from 'react'
-import { LoaderCircleIcon, SearchIcon, XIcon } from 'lucide-react'
-import { Form, useNavigation, useSearchParams, useSubmit } from 'react-router'
+import { SearchIcon, XIcon } from 'lucide-react'
+import { useNavigate, useSearchParams } from 'react-router'
 
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 
-// Wait a beat after the last keystroke before hitting the loader, so live
-// filtering doesn't fire a request on every character.
-const DEBOUNCE_MS = 300
-
-/**
- * Keyword search for the public blog archive.
- *
- * Follows the React Router data pattern for search/filter UIs: a GET `<Form>`
- * serialises its fields into the URL and re-runs the route loader (searching is
- * a read, so it belongs in the loader, not an action). `useSubmit` drives
- * debounced live filtering, and the input value stays in sync with the URL so
- * browser back/forward keeps working.
- */
 export function BlogSearchForm() {
   const [searchParams] = useSearchParams()
-  const submit = useSubmit()
-  const navigation = useNavigation()
+  const navigate = useNavigate()
+  const currentKeyword = searchParams.get('keyword')?.trim() ?? ''
 
-  const keyword = searchParams.get('keyword') ?? ''
-  // Preserve the chosen page size across searches (reset to page 1 implicitly,
-  // since `page` is not part of this form).
-  const pageSize = searchParams.get('page_size') ?? ''
-
-  // A keyword navigation is in flight. For GET submissions the pending data
-  // lives in `navigation.location.search`, not `navigation.formData`.
-  const searching =
-    navigation.location != null &&
-    new URLSearchParams(navigation.location.search).has('keyword')
-
-  // Keep the uncontrolled input in sync with the URL (e.g. on back/forward).
-  const inputRef = useRef<HTMLInputElement>(null)
-  useEffect(() => {
-    if (inputRef.current) inputRef.current.value = keyword
-  }, [keyword])
-
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  function handleChange(event: React.FormEvent<HTMLFormElement>) {
-    const form = event.currentTarget
-    // Push a history entry for the first search, then replace it on subsequent
-    // keystrokes so the back button returns to the unfiltered list in one step.
-    const isFirstSearch = keyword === ''
-    clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(() => {
-      submit(form, { replace: !isFirstSearch })
-    }, DEBOUNCE_MS)
+  function navigateWithKeyword(keyword: string) {
+    const params = new URLSearchParams()
+    // Preserve the page size but reset to the first page on a new search.
+    const pageSize = searchParams.get('page_size')
+    if (pageSize) params.set('page_size', pageSize)
+    if (keyword) params.set('keyword', keyword)
+    navigate(`?${params}`)
   }
 
-  function handleClear() {
-    if (inputRef.current) inputRef.current.value = ''
-    clearTimeout(timerRef.current)
-    inputRef.current?.form?.requestSubmit()
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const value = new FormData(event.currentTarget).get('keyword')
+    navigateWithKeyword(typeof value === 'string' ? value.trim() : '')
   }
 
   return (
-    <Form
-      method="get"
+    <form
+      onSubmit={handleSubmit}
       role="search"
-      onChange={handleChange}
-      onSubmit={() => clearTimeout(timerRef.current)}
       className="mb-8 flex items-center gap-2"
     >
-      {pageSize && <input type="hidden" name="page_size" value={pageSize} />}
       <div className="relative flex-1">
-        {searching ? (
-          <LoaderCircleIcon
-            aria-hidden
-            className="absolute top-1/2 left-3 size-4 -translate-y-1/2 animate-spin text-muted-foreground"
-          />
-        ) : (
-          <SearchIcon
-            aria-hidden
-            className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-          />
-        )}
+        <SearchIcon
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+        />
         <Input
-          ref={inputRef}
+          key={currentKeyword}
           type="search"
           name="keyword"
-          defaultValue={keyword}
+          defaultValue={currentKeyword}
           placeholder="タイトル・概要・著者で検索"
           aria-label="ブログ記事を検索"
           className="pl-9"
         />
       </div>
-      {keyword && (
-        <Button type="button" variant="ghost" onClick={handleClear}>
+      {currentKeyword && (
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => navigateWithKeyword('')}
+        >
           <XIcon className="size-4" />
           クリア
         </Button>
       )}
-    </Form>
+      <Button type="submit">検索</Button>
+    </form>
   )
 }

--- a/frontend/app/components/blog/blog-search-form.tsx
+++ b/frontend/app/components/blog/blog-search-form.tsx
@@ -1,0 +1,61 @@
+import { SearchIcon, XIcon } from 'lucide-react'
+import { useNavigate, useSearchParams } from 'react-router'
+
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+
+export function BlogSearchForm() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const currentKeyword = searchParams.get('keyword')?.trim() ?? ''
+
+  function navigateWithKeyword(keyword: string) {
+    const params = new URLSearchParams()
+    // Preserve the page size but reset to the first page on a new search.
+    const pageSize = searchParams.get('page_size')
+    if (pageSize) params.set('page_size', pageSize)
+    if (keyword) params.set('keyword', keyword)
+    navigate(`?${params}`)
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const value = new FormData(event.currentTarget).get('keyword')
+    navigateWithKeyword(typeof value === 'string' ? value.trim() : '')
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      role="search"
+      className="mb-8 flex items-center gap-2"
+    >
+      <div className="relative flex-1">
+        <SearchIcon
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          key={currentKeyword}
+          type="search"
+          name="keyword"
+          defaultValue={currentKeyword}
+          placeholder="タイトル・概要・著者で検索"
+          aria-label="ブログ記事を検索"
+          className="pl-9"
+        />
+      </div>
+      {currentKeyword && (
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => navigateWithKeyword('')}
+        >
+          <XIcon className="size-4" />
+          クリア
+        </Button>
+      )}
+      <Button type="submit">検索</Button>
+    </form>
+  )
+}

--- a/frontend/app/routes/blog.tsx
+++ b/frontend/app/routes/blog.tsx
@@ -8,6 +8,7 @@ import {
   parsePageParams,
 } from '~/components/blog/blog-list-pagination'
 import { BlogPostCard } from '~/components/blog/blog-post-card'
+import { BlogSearchForm } from '~/components/blog/blog-search-form'
 import type { PaginatedBlogPostResponseSchema } from '~/api/types.gen'
 import type { Route } from './+types/blog'
 
@@ -19,17 +20,17 @@ export function meta() {
 }
 
 export function clientLoader({ request }: Route.ClientLoaderArgs) {
-  const { page, pageSize } = parsePageParams(new URL(request.url))
+  const { page, pageSize, keyword } = parsePageParams(new URL(request.url))
 
   const blogs = listBlogsApiV1BlogGet({
     baseUrl: import.meta.env.VITE_API_BASE_URL,
-    query: { page, page_size: pageSize },
+    query: { page, page_size: pageSize, keyword },
   }).then(({ data, error }) => {
     if (error || !data)
       throw new Response('Failed to load archive', { status: 500 })
     return data
   })
-  return { blogs }
+  return { blogs, keyword }
 }
 
 export function HydrateFallback() {
@@ -37,15 +38,28 @@ export function HydrateFallback() {
     <main className="h-full overflow-y-auto px-4 py-12" aria-busy="true">
       <div className="mx-auto max-w-3xl">
         <h1 className="mb-8 text-2xl font-bold text-foreground">アーカイブ</h1>
+        <BlogSearchForm />
         <BlogListSkeleton count={4} />
       </div>
     </main>
   )
 }
 
-function BlogPostList({ data }: { data: PaginatedBlogPostResponseSchema }) {
+function BlogPostList({
+  data,
+  keyword,
+}: {
+  data: PaginatedBlogPostResponseSchema
+  keyword?: string
+}) {
   if (data.items.length === 0) {
-    return <p className="text-muted-foreground">まだブログ記事がありません。</p>
+    return (
+      <p className="text-muted-foreground">
+        {keyword
+          ? `「${keyword}」に一致するブログ記事が見つかりませんでした。`
+          : 'まだブログ記事がありません。'}
+      </p>
+    )
   }
   return (
     <>
@@ -60,6 +74,7 @@ function BlogPostList({ data }: { data: PaginatedBlogPostResponseSchema }) {
         currentPage={data.page}
         totalPages={data.total_pages}
         pageSize={data.page_size}
+        keyword={keyword}
       />
     </>
   )
@@ -70,9 +85,10 @@ export default function BlogList({ loaderData }: Route.ComponentProps) {
     <main className="h-full overflow-y-auto px-4 py-12">
       <div className="mx-auto max-w-3xl">
         <h1 className="mb-8 text-2xl font-bold text-foreground">アーカイブ</h1>
+        <BlogSearchForm />
         <Suspense fallback={<BlogListSkeleton count={4} />}>
           <Await resolve={loaderData.blogs}>
-            {data => <BlogPostList data={data} />}
+            {data => <BlogPostList data={data} keyword={loaderData.keyword} />}
           </Await>
         </Suspense>
       </div>


### PR DESCRIPTION
## 概要

公開ブログ一覧（`/blog` アーカイブ）にキーワード検索機能を追加しました。記事数が増えても目的の論文記事を探しやすくするのが目的です。

## 変更内容

### バックエンド
- `GET /api/v1/blog/` に `keyword` クエリパラメータを追加
- `title` / `summary` / `authors` を対象に **ILIKE による部分一致**（大文字小文字を無視）で絞り込み
  - `authors` は `array_to_string(authors, ' ')` に対して ILIKE
- Repository インターフェイス・実装・UseCase・Controller を更新
- `find_all` / `count_all` で再利用する `_keyword_condition` ヘルパーを追加
- `openapi.json` を `gen-oapi` で再生成

### フロントエンド
- shadcn `Input` + lucide 検索アイコンベースの検索フォーム `blog-search-form.tsx` を追加
- 状態は既存のページネーションと同様に URL search param (`?keyword=...`) で管理し、`clientLoader` で再取得
- ページ送り・表示件数変更時も検索語を URL に保持
- 検索結果 0 件時のメッセージを検索中／通常で出し分け
- API クライアントを `generate-api` で再生成

## 検証
- backend: `ruff check` / `mypy` 通過
- frontend: `typecheck` / `lint` / `prettier --check` 通過
- 手動 E2E は未実施（要ローカル環境）

## 対象外
- `/my-blogs`（マイブログ）への検索追加は今回スコープ外

https://claude.ai/code/session_01EQD4qUvrmSwE65zcA26w6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQD4qUvrmSwE65zcA26w6Q)_