### PR TITLE
feat(frontend): Cloudflare Cronでbackendのコールドスタートを対策

### DIFF
--- a/frontend/workers/app.ts
+++ b/frontend/workers/app.ts
@@ -20,4 +20,21 @@ export default {
       cloudflare: { env, ctx },
     })
   },
+  // Render 無料プランは15分無アクセスでスピンダウンするため、
+  // backend のヘルスエンドポイントを定期 ping して常時ウォーム状態に保つ。
+  async scheduled(_controller, env, ctx) {
+    ctx.waitUntil(
+      (async () => {
+        try {
+          const res = await fetch(`${env.API_BASE_URL}/`, {
+            method: 'GET',
+            headers: { 'User-Agent': 'jaxiv-keepalive/1.0' },
+          })
+          console.log(`keepalive: backend responded ${res.status}`)
+        } catch (err) {
+          console.error('keepalive: backend ping failed', err)
+        }
+      })(),
+    )
+  },
 } satisfies ExportedHandler<Env>

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -11,4 +11,8 @@
   },
   "main": "./workers/app.ts",
   "compatibility_flags": ["nodejs_compat"],
+  // Render 無料プランのスピンダウン(15分)対策。10分ごとに backend を ping してウォーム状態を維持する。
+  "triggers": {
+    "crons": ["*/10 * * * *"],
+  },
 }


### PR DESCRIPTION
## 背景・目的

Render 無料プランの backend (`arxiv-translation-service`) は **15分間アクセスがないとスピンダウン** し、次回アクセス時に約1分のコールドスタートが発生する。フロントのページ読み込み時の UX を大きく損なっていた。

対策として「定期的に軽量リクエストを送り続けてスピンダウンを防ぐ」方式を実装。フロントが既に **Cloudflare Workers** 上で稼働しているため、同じ Worker に **Cron Trigger + `scheduled` ハンドラ** を追加して backend のヘルスエンドポイントを叩く。

> 方式比較: GitHub Actions のスケジュールは混雑時に5〜15分以上遅延しがちで15分のスピンダウン窓を外すリスクがあるのに対し、Cloudflare Cron はタイミングが正確で追加アカウント不要・リポジトリ管理できるため採用。

## 変更内容

- **`frontend/workers/app.ts`**: `scheduled` ハンドラを追加。`ctx.waitUntil` で `${env.API_BASE_URL}/`（backend 既存の `GET /` 軽量応答）を ping し、結果を `console.log`（observability 有効）に記録。
- **`frontend/wrangler.jsonc`**: `triggers.crons` に `*/10 * * * *`（10分間隔）を追加。15分のスピンダウン窓に対し5分の余裕を持たせる。

## 重要な制約と設計判断

Render 無料枠は **ワークスペース全体で月750インスタンス時間を共有**（[docs](https://render.com/docs/free)）。

- 1サービス24時間稼働 ≒ 720h/月 → 枠内。
- 2サービス常時稼働 ≒ 1440h/月 → 月途中で枠超過し**全無料サービスが停止**するリスク。
- → **24時間温める対象は UX 影響の大きい backend のみに限定**。tex_translation / pdf_analysis は翻訳実行時のオンデマンド起動（翻訳自体が数分かかるため相対的影響が小さい）で許容。

## 検証手順

1. 型チェック: `cd frontend && npm run cf-typegen && npm run typecheck` ✅（ローカルで確認済み）
2. ローカル scheduled 確認: `npm run build && npx wrangler dev --test-scheduled` → `curl "http://localhost:8787/__scheduled?cron=*/10+*+*+*+*"` で `keepalive: backend responded 200` がログに出ること
3. デプロイ: `cd frontend && npm run deploy`
4. デプロイ後:
   - Cloudflare ダッシュボード → Worker `jaxiv-frontend` → Triggers に Cron 登録、Observability に10分ごとの `keepalive` ログ
   - Render ダッシュボードで `arxiv-translation-service` が `Live` を維持、Metrics に10分間隔のリクエスト
   - 月末に Render 無料インスタンス時間が750hを超えていないこと（backend単独なら約720hで枠内）

## 補足

- backend を有料プラン化した場合は本 cron は不要になるため削除する。
- tex/pdf も日中だけ温めたくなった場合は、`scheduled` 内で時刻（UTC→JST換算）を見て対象URLを出し分ける形に拡張可能（750h枠の範囲で）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017chuxPV93dkXpES2fBvY1M)_