### PR TITLE
feat(blog): arXiv LaTeXソースの構造化前処理でブログ生成精度を改善

### DIFF
--- a/backend/infrastructure/gemini/config.py
+++ b/backend/infrastructure/gemini/config.py
@@ -8,6 +8,11 @@ class GeminiConfig(BaseSettings):
 	gemini_api_key: SecretStr = Field(
 		default=SecretStr(''), description='The API key for the Gemini API'
 	)
+	blog_model: str = Field(
+		default='gemini-3-flash-preview',
+		description='Model used for blog post generation (override via GEMINI_BLOG_MODEL)',
+		alias='GEMINI_BLOG_MODEL',
+	)
 
 
 @lru_cache

--- a/backend/infrastructure/gemini/gemini_blog_post_generator.py
+++ b/backend/infrastructure/gemini/gemini_blog_post_generator.py
@@ -21,6 +21,7 @@ from domain.entities.figure import UploadedFigure
 from domain.entities.pdf_paper import PdfPaperMetadata
 from domain.gateways import IBlogPostGenerator, IPdfBlogPostGenerator
 from infrastructure.gemini.config import get_gemini_config
+from infrastructure.latex import LatexPreprocessor
 
 
 class PdfBlogResponse(BaseModel):
@@ -42,13 +43,14 @@ class GeminiBlogPostGenerator(IBlogPostGenerator, IPdfBlogPostGenerator):
 
 	def __init__(
 		self,
-		model: str = 'gemini-3-flash-preview',
+		model: str | None = None,
 		max_latex_chars: int = 80_000,
 	):
 		self.client = genai.Client(api_key=gemini_config.gemini_api_key.get_secret_value())
 		self.logger = getLogger(__name__)
-		self.model: Final[str] = model
+		self.model: Final[str] = model or gemini_config.blog_model
 		self.max_latex_chars: Final[int] = max_latex_chars
+		self._latex = LatexPreprocessor()
 
 	@property
 	def system_prompt(self) -> str:
@@ -85,7 +87,8 @@ arXiv 論文情報をもとに Markdown 形式でブログ記事を執筆して�
 
 # 数式ルール（KaTeX）
 - インライン: `$...$` / ブロック: `$$...$$`（前後に空行必須）
-- `\\newcommand`/`\\def` のカスタムマクロは標準 KaTeX コマンドに展開すること
+- 「著者定義マクロ」セクションが与えられた場合、その定義に**厳密に従って**標準 KaTeX コマンドへ展開すること（マクロ名をそのまま出力してはならない）
+- セクションに無い `\\newcommand`/`\\def` マクロも標準 KaTeX に展開すること
 - 旧式コマンド（`\\tt`/`\\bf`/`\\it`/`\\rm` 等）禁止 → `\\texttt{}`/`\\textbf{}`/`\\textit{}`/`\\textrm{}`
 - 数式中のテキストは `\\text{}` を使用（`\\mbox{}` 禁止）
 - `\\label{}`/`\\ref{}` は使わず文脈で説明すること
@@ -142,20 +145,17 @@ arXiv 論文情報をもとに Markdown 形式でブログ記事を執筆して�
 		latex_source_dir: Path,
 		figure_urls: dict[str, str],
 	) -> str:
-		# LaTeX ソース読み込み
-		tex_parts: list[str] = []
-		total = 0
-		for tex_file in sorted(latex_source_dir.rglob('*.tex')):
-			try:
-				text = tex_file.read_text(encoding='utf-8', errors='ignore')
-				if total + len(text) > self.max_latex_chars:
-					tex_parts.append(text[: self.max_latex_chars - total])
-					break
-				tex_parts.append(text)
-				total += len(text)
-			except Exception:
-				self.logger.warning('Failed to read %s', tex_file, exc_info=True)
-		latex_content = '\n\n'.join(tex_parts)
+		# LaTeX ソースをドキュメント順に結合し、著者定義マクロを抽出
+		assembled = self._latex.assemble(latex_source_dir)
+		latex_content = assembled.body[: self.max_latex_chars]
+
+		macro_section = ''
+		if assembled.macros:
+			macro_lines = '\n'.join(assembled.macros)
+			macro_section = (
+				'# 著者定義マクロ（必ずこの定義に従って数式を展開すること）\n'
+				f'```latex\n{macro_lines}\n```\n\n'
+			)
 
 		# 図URL一覧セクション（プレースホルダを使用）
 		figure_section = ''
@@ -177,6 +177,7 @@ arXiv 論文情報をもとに Markdown 形式でブログ記事を執筆して�
 			f'- arXiv ID: {paper_metadata.paper_id.root}\n'
 			f'- 概要:\n{paper_metadata.summary}\n\n'
 			f'{figure_section}'
+			f'{macro_section}'
 			f'# LaTeX ソースコード（抜粋）\n'
 			f'```latex\n{latex_content}\n```\n\n'
 			'上記の情報をもとに、日本語のブログ記事を Markdown 形式で作成してください。'

--- a/backend/infrastructure/latex/__init__.py
+++ b/backend/infrastructure/latex/__init__.py
@@ -1,0 +1,3 @@
+from .latex_preprocessor import AssembledLatex, LatexPreprocessor
+
+__all__ = ['AssembledLatex', 'LatexPreprocessor']

--- a/backend/infrastructure/latex/latex_preprocessor.py
+++ b/backend/infrastructure/latex/latex_preprocessor.py
@@ -1,0 +1,177 @@
+"""LaTeX source preprocessing for blog generation.
+
+arXiv papers are distributed as LaTeX source (e-print), which is far more
+reliable than PDF/OCR for preserving structure, equations and figures.  But
+feeding the raw source to an LLM has three failure modes that this module
+fixes:
+
+1. Multi-file papers split across ``\\input``/``\\include`` must be assembled
+   in document order — globbing ``*.tex`` alphabetically scrambles structure
+   and can truncate the body to leave only an appendix.
+2. Author-defined macros (``\\newcommand``/``\\def`` …) must be visible and
+   intact, otherwise the LLM "mentally expands" them and corrupts the math.
+3. ``%`` comments are noise that confuses generation.
+
+The public entry point is :meth:`LatexPreprocessor.assemble`.
+"""
+
+import re
+from logging import getLogger
+from pathlib import Path
+from typing import Final
+
+from pydantic import BaseModel, Field
+
+# \input{file}, \include{file}, \subfile{file} (optional .tex extension)
+_INCLUDE_RE: Final[re.Pattern[str]] = re.compile(r'\\(?:input|include|subfile)\s*\{([^}]+)\}')
+# Author-defined macros worth surfacing to the LLM verbatim.
+_MACRO_RE: Final[re.Pattern[str]] = re.compile(
+	r'^\s*\\(?:newcommand|renewcommand|providecommand|def|let'
+	r'|DeclareMathOperator|newenvironment)\*?\b'
+)
+# An unescaped % starts a comment that runs to end of line.
+_COMMENT_RE: Final[re.Pattern[str]] = re.compile(r'(?<!\\)%.*')
+
+_MAX_INCLUDE_DEPTH: Final[int] = 16
+
+
+class AssembledLatex(BaseModel):
+	"""Result of assembling a paper's LaTeX source."""
+
+	body: str = Field(description='ドキュメント順に結合・整形した LaTeX 本文')
+	macros: list[str] = Field(
+		default_factory=list,
+		description='著者定義マクロ（\\newcommand/\\def 等）の定義行',
+	)
+
+
+class LatexPreprocessor:
+	"""Assemble and clean a paper's LaTeX source for LLM consumption."""
+
+	def __init__(self) -> None:
+		self._logger = getLogger(__name__)
+
+	def assemble(self, source_dir: Path, main_tex_file: str | None = None) -> AssembledLatex:
+		"""Assemble the document starting from its main ``.tex`` file.
+
+		Args:
+		    source_dir: Directory containing the extracted LaTeX source.
+		    main_tex_file: Filename of the toplevel ``.tex`` (e.g. from arXiv's
+		        ``00README.json``).  When ``None`` it is detected by scanning
+		        for ``\\begin{document}``.
+
+		Returns:
+		    The assembled body (comments stripped, includes resolved) together
+		    with the list of author-defined macro definitions.
+		"""
+		main_path = self._resolve_main_path(source_dir, main_tex_file)
+		if main_path is None:
+			self._logger.warning(
+				'No main .tex found in %s; falling back to concatenation', source_dir
+			)
+			return self._fallback_concat(source_dir)
+
+		self._logger.info('Assembling LaTeX from main file %s', main_path.name)
+		body = self._expand_includes(main_path, source_dir, visited=set(), depth=0)
+		macros = self._extract_macros(body)
+		return AssembledLatex(body=body, macros=macros)
+
+	# ------------------------------------------------------------------
+	# Main-file detection
+	# ------------------------------------------------------------------
+
+	def _resolve_main_path(self, source_dir: Path, main_tex_file: str | None) -> Path | None:
+		if main_tex_file:
+			candidate = source_dir / main_tex_file
+			if candidate.exists():
+				return candidate
+			# README may give a path relative to a subdir; search by name.
+			for match in source_dir.rglob(main_tex_file):
+				return match
+
+		# Detect by \documentclass + \begin{document}; prefer files with both.
+		best: Path | None = None
+		for tex_file in sorted(source_dir.rglob('*.tex')):
+			text = self._read(tex_file)
+			if '\\begin{document}' not in text:
+				continue
+			if '\\documentclass' in text:
+				return tex_file
+			best = best or tex_file
+		return best
+
+	# ------------------------------------------------------------------
+	# Include resolution
+	# ------------------------------------------------------------------
+
+	def _expand_includes(
+		self, tex_path: Path, source_dir: Path, visited: set[Path], depth: int
+	) -> str:
+		resolved = tex_path.resolve()
+		if resolved in visited or depth > _MAX_INCLUDE_DEPTH:
+			return ''
+		visited.add(resolved)
+
+		out: list[str] = []
+		for raw_line in self._read(tex_path).splitlines():
+			line = _COMMENT_RE.sub('', raw_line)
+			match = _INCLUDE_RE.search(line)
+			if match is None:
+				out.append(line)
+				continue
+
+			included = self._resolve_include_target(match.group(1), tex_path, source_dir)
+			before = line[: match.start()].rstrip()
+			if before:
+				out.append(before)
+			if included is not None:
+				out.append(self._expand_includes(included, source_dir, visited, depth + 1))
+			else:
+				self._logger.debug('Unresolved include %r in %s', match.group(1), tex_path.name)
+		return '\n'.join(out)
+
+	@staticmethod
+	def _resolve_include_target(target: str, tex_path: Path, source_dir: Path) -> Path | None:
+		target = target.strip()
+		names = (target, f'{target}.tex')
+		search_roots = (tex_path.parent, source_dir)
+		for root in search_roots:
+			for name in names:
+				candidate = root / name
+				if candidate.exists() and candidate.is_file():
+					return candidate
+		return None
+
+	# ------------------------------------------------------------------
+	# Macro extraction
+	# ------------------------------------------------------------------
+
+	@staticmethod
+	def _extract_macros(body: str) -> list[str]:
+		macros: list[str] = []
+		seen: set[str] = set()
+		for line in body.splitlines():
+			if _MACRO_RE.match(line):
+				stripped = line.strip()
+				if stripped not in seen:
+					seen.add(stripped)
+					macros.append(stripped)
+		return macros
+
+	# ------------------------------------------------------------------
+	# Fallbacks / IO
+	# ------------------------------------------------------------------
+
+	def _fallback_concat(self, source_dir: Path) -> AssembledLatex:
+		parts = [self._read(f) for f in sorted(source_dir.rglob('*.tex'))]
+		body = '\n\n'.join(
+			'\n'.join(_COMMENT_RE.sub('', line) for line in part.splitlines()) for part in parts
+		)
+		return AssembledLatex(body=body, macros=self._extract_macros(body))
+
+	def _read(self, path: Path) -> str:
+		try:
+			return path.read_text(encoding='utf-8', errors='ignore')
+		except Exception:
+			self._logger.warning('Failed to read %s', path, exc_info=True)
+			return ''


### PR DESCRIPTION
## 背景

ブログ生成の精度が低い問題を調査したところ、arXiv パスの**入力品質**に主因があることが分かりました。

`ArxivSourceFetcher` は README / `\begin{document}` からメイン `.tex` を正しく特定しているにもかかわらず、その結果は破棄され（`generate_blog_post.py`）、生成側（`gemini_blog_post_generator.py`）では `sorted(rglob('*.tex'))` で**全 `.tex` をアルファベット順に連結**してから先頭 80k 文字で打ち切っていました。これにより、

- マルチファイル論文（arXiv では一般的）で**文書構造が崩壊**し、付録だけが渡るケースが発生
- プリアンブルの `\newcommand`/`\def` カスタムマクロが生のまま渡され、LLM の「暗算展開」で**数式が崩壊**

していました。

## 変更内容

- **LaTeX 構造化前処理 `LatexPreprocessor` を追加**（`infrastructure/latex/`）
  - メイン `.tex` を起点に `\input`/`\include`/`\subfile` を**文書順に再帰解決**して結合（順序崩壊・付録のみ抽出を解消）
  - 著者定義マクロ（`\newcommand`/`\def`/`\DeclareMathOperator` 等）を抽出し、プロンプトに**マクロ辞書として明示供給**（暗算展開による数式崩壊を防止）
  - `%` コメントを除去（`\%` は保持）してノイズ削減
- **ブログ生成モデルを環境変数で切替可能化**：`GEMINI_BLOG_MODEL`（デフォルトは従来の `gemini-3-flash-preview`）。コード変更なしで Gemini 3 Pro 等へ昇格可能
- システムプロンプトの数式ルールを「与えられたマクロ定義に厳密に従って展開する」よう更新

## 動作確認

- 合成マルチファイル論文での前処理の単体検証：マクロ抽出・コメント除去（`\%` 保持）・`\input` の文書順解決・非インクルード付録の除外をすべて確認
- `ruff check` / `ruff format --check` / `mypy` すべて通過

## 補足（未対応・今後の検討）

- PDF パスは引き続き Gemini ネイティブ読解。崩壊が残る場合は Mistral OCR フォールバックや「アウトライン→セクション展開」の 2 段生成、KaTeX バリデーション＋自動リペアを別 PR で検討予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR61z8VDgEPx1QQFnBxxTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR61z8VDgEPx1QQFnBxxTQ)_