### PR TITLE
feat(frontend): ブログ記事ページにSEO/OGPメタ情報を追加

### DIFF
--- a/backend/application/usecase/suggest_figures.py
+++ b/backend/application/usecase/suggest_figures.py
@@ -6,6 +6,7 @@ from domain.gateways.i_figure_query_generator import IFigureQueryGenerator
 from domain.gateways.i_query_embedding_gateway import IQueryEmbeddingGateway
 from domain.repositories.i_blog_post_repository import IBlogPostRepository
 from domain.repositories.i_figure_chunk_repository import GlobalFigureHit, IFigureChunkRepository
+from domain.value_objects.blog_source_type import BlogSourceType
 from domain.value_objects.user_id import UserId
 
 
@@ -17,6 +18,7 @@ class FigureSuggestionItem(BaseModel):
 	page_number: int
 	paper_id: str
 	paper_title: str | None
+	source_type: BlogSourceType
 	score: float
 	matched_query: str
 
@@ -80,12 +82,12 @@ class SuggestFiguresUseCase:
 					best[hit.image_url] = (hit, query)
 
 		# Drop figures the requester may not access (other users' private PDFs).
-		# This also yields the title map for the accessible papers.
-		titles = await self._blog_post_repository.find_accessible_titles_by_paper_ids(
+		# This also yields the title / source type for the accessible papers.
+		papers = await self._blog_post_repository.find_accessible_papers_by_paper_ids(
 			list({hit.paper_id for hit, _ in best.values()}),
 			requester_user_id,
 		)
-		accessible = [pair for pair in best.values() if pair[0].paper_id in titles]
+		accessible = [pair for pair in best.values() if pair[0].paper_id in papers]
 		ranked = sorted(accessible, key=lambda pair: pair[0].score, reverse=True)[:limit]
 
 		return SuggestFiguresResult(
@@ -96,7 +98,8 @@ class SuggestFiguresUseCase:
 					caption=hit.caption,
 					page_number=hit.page_number,
 					paper_id=hit.paper_id,
-					paper_title=titles.get(hit.paper_id) or None,
+					paper_title=papers[hit.paper_id].title or None,
+					source_type=papers[hit.paper_id].source_type,
 					score=hit.score,
 					matched_query=query,
 				)

--- a/backend/controller/schemas/blog_response.py
+++ b/backend/controller/schemas/blog_response.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -15,6 +16,7 @@ class BlogPostResponseSchema(BaseModel):
 	summary: str
 	authors: list[str]
 	source_url: str | None
+	source_type: Literal['arxiv', 'pdf']
 	content: str
 	created_at: datetime
 	updated_at: datetime
@@ -27,6 +29,7 @@ class BlogPostResponseSchema(BaseModel):
 			summary=blog_post.summary,
 			authors=blog_post.authors,
 			source_url=blog_post.source_url,
+			source_type='pdf' if blog_post.source_type.is_pdf else 'arxiv',
 			content=blog_post.content,
 			created_at=blog_post.created_at,
 			updated_at=blog_post.updated_at,

--- a/backend/controller/schemas/figure_suggestion_response.py
+++ b/backend/controller/schemas/figure_suggestion_response.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from application.usecase.suggest_figures import SuggestFiguresResult
@@ -20,6 +22,7 @@ class FigureSuggestionItemSchema(BaseModel):
 	page_number: int
 	paper_id: str
 	paper_title: str | None
+	source_type: Literal['arxiv', 'pdf']
 	score: float
 	matched_query: str
 
@@ -41,6 +44,7 @@ class FigureSuggestionResponseSchema(BaseModel):
 					page_number=i.page_number,
 					paper_id=i.paper_id,
 					paper_title=i.paper_title,
+					source_type='pdf' if i.source_type.is_pdf else 'arxiv',
 					score=i.score,
 					matched_query=i.matched_query,
 				)

--- a/backend/domain/repositories/i_blog_post_repository.py
+++ b/backend/domain/repositories/i_blog_post_repository.py
@@ -1,8 +1,20 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 
+from pydantic import BaseModel, ConfigDict
+
 from domain.entities.blog import BlogPost
+from domain.value_objects.blog_source_type import BlogSourceType
 from domain.value_objects.user_id import UserId
+
+
+class AccessiblePaper(BaseModel):
+	"""Lightweight read model for a paper the requester may access."""
+
+	model_config = ConfigDict(frozen=True)
+
+	title: str
+	source_type: BlogSourceType
 
 
 class IBlogPostRepository(ABC):
@@ -14,10 +26,10 @@ class IBlogPostRepository(ABC):
 		...
 
 	@abstractmethod
-	async def find_accessible_titles_by_paper_ids(
+	async def find_accessible_papers_by_paper_ids(
 		self, paper_ids: list[str], user_id: UserId
-	) -> dict[str, str]:
-		"""Return paper_id -> title for papers the given user may access.
+	) -> dict[str, AccessiblePaper]:
+		"""Return paper_id -> accessible paper info for papers the user may access.
 
 		A paper is accessible when it is a public arXiv post, or a PDF post owned
 		by ``user_id``. Inaccessible papers (e.g. other users' private PDFs) and

--- a/backend/infrastructure/postgres/repositories/postgres_blog_post_repository.py
+++ b/backend/infrastructure/postgres/repositories/postgres_blog_post_repository.py
@@ -7,6 +7,7 @@ from sqlmodel import col
 
 from domain.entities.blog import BlogPost
 from domain.repositories import IBlogPostRepository
+from domain.repositories.i_blog_post_repository import AccessiblePaper
 from domain.value_objects.blog_source_type import BlogSourceType
 from domain.value_objects.user_id import UserId
 
@@ -125,10 +126,10 @@ class PostgresBlogPostRepository(IBlogPostRepository):
 		result = await self._session.execute(statement)
 		return result.scalar_one()
 
-	async def find_accessible_titles_by_paper_ids(
+	async def find_accessible_papers_by_paper_ids(
 		self, paper_ids: list[str], user_id: UserId
-	) -> dict[str, str]:
-		"""Return paper_id -> title for papers the given user may access.
+	) -> dict[str, AccessiblePaper]:
+		"""Return paper_id -> accessible paper info for papers the given user may access.
 
 		Accessible papers are public arXiv posts or PDF posts owned by ``user_id``.
 		Other users' private PDF posts and unknown paper IDs are omitted.
@@ -136,7 +137,9 @@ class PostgresBlogPostRepository(IBlogPostRepository):
 		if not paper_ids:
 			return {}
 		statement = select(
-			col(BlogPostContentModel.paper_id), col(BlogPostContentModel.title)
+			col(BlogPostContentModel.paper_id),
+			col(BlogPostContentModel.title),
+			col(BlogPostContentModel.source_type),
 		).where(
 			col(BlogPostContentModel.paper_id).in_(paper_ids),
 			or_(
@@ -145,7 +148,12 @@ class PostgresBlogPostRepository(IBlogPostRepository):
 			),
 		)
 		result = await self._session.execute(statement)
-		return {paper_id: (title or '') for paper_id, title in result.all()}
+		return {
+			paper_id: AccessiblePaper(
+				title=title or '', source_type=BlogSourceType(source_type)
+			)
+			for paper_id, title, source_type in result.all()
+		}
 
 	async def find_by_paper_id(self, paper_id: str) -> BlogPost | None:
 		statement = select(BlogPostContentModel).where(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -951,6 +951,14 @@
             ],
             "title": "Source Url"
           },
+          "source_type": {
+            "type": "string",
+            "enum": [
+              "arxiv",
+              "pdf"
+            ],
+            "title": "Source Type"
+          },
           "content": {
             "type": "string",
             "title": "Content"
@@ -973,6 +981,7 @@
           "summary",
           "authors",
           "source_url",
+          "source_type",
           "content",
           "created_at",
           "updated_at"
@@ -1246,6 +1255,14 @@
             ],
             "title": "Paper Title"
           },
+          "source_type": {
+            "type": "string",
+            "enum": [
+              "arxiv",
+              "pdf"
+            ],
+            "title": "Source Type"
+          },
           "score": {
             "type": "number",
             "title": "Score"
@@ -1262,6 +1279,7 @@
           "page_number",
           "paper_id",
           "paper_title",
+          "source_type",
           "score",
           "matched_query"
         ],

--- a/frontend/app/api/types.gen.ts
+++ b/frontend/app/api/types.gen.ts
@@ -29,6 +29,10 @@ export type BlogPostResponseSchema = {
    */
   source_url: string | null
   /**
+   * Source Type
+   */
+  source_type: 'arxiv' | 'pdf'
+  /**
    * Content
    */
   content: string
@@ -220,6 +224,10 @@ export type FigureSuggestionItemSchema = {
    * Paper Title
    */
   paper_title: string | null
+  /**
+   * Source Type
+   */
+  source_type: 'arxiv' | 'pdf'
   /**
    * Score
    */

--- a/frontend/app/components/blog/blog-post-card.tsx
+++ b/frontend/app/components/blog/blog-post-card.tsx
@@ -13,7 +13,7 @@ export function BlogPostCard({
 }) {
   return (
     <Link
-      to={blogPostPath(post.paper_id)}
+      to={blogPostPath(post.paper_id, post.source_type)}
       className="group flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-md"
     >
       {showPaperId && (

--- a/frontend/app/components/blog/blog-post-card.tsx
+++ b/frontend/app/components/blog/blog-post-card.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router'
 import { FileTextIcon } from 'lucide-react'
 
 import type { BlogPostResponseSchema } from '~/api/types.gen'
+import { blogPostPath } from '~/lib/blog-path'
 
 export function BlogPostCard({
   post,
@@ -12,7 +13,7 @@ export function BlogPostCard({
 }) {
   return (
     <Link
-      to={`/blog/${post.paper_id}`}
+      to={blogPostPath(post.paper_id)}
       className="group flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-md"
     >
       {showPaperId && (

--- a/frontend/app/components/blog/blog-post-view.tsx
+++ b/frontend/app/components/blog/blog-post-view.tsx
@@ -1,0 +1,156 @@
+import { useEffect } from 'react'
+import { BlogPaperChat } from '~/components/blog-paper-chat'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '~/components/ui/resizable'
+import { useIsMobile } from '~/hooks/use-mobile'
+import type { BlogPostResponseSchema } from '~/api/types.gen'
+
+export type BlogPostWithHtml = BlogPostResponseSchema & { contentHtml: string }
+
+// arXiv記事（SSR）とPDF記事（clientLoader）で共通の表示コンポーネント。
+export function BlogPostView({
+  post,
+  paperId,
+}: {
+  post: BlogPostWithHtml
+  paperId: string
+}) {
+  const isMobile = useIsMobile()
+
+  useEffect(() => {
+    import('zenn-embed-elements')
+  }, [])
+
+  const blogPanel = (
+    <div className="mx-auto max-w-3xl">
+      {(post.authors.length > 0 || post.source_url) && (
+        <header className="mb-8 space-y-2">
+          {post.authors.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              {post.authors.join(', ')}
+            </p>
+          )}
+          {post.source_url && (
+            <a
+              href={post.source_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm text-primary hover:underline"
+            >
+              {post.source_url}
+            </a>
+          )}
+        </header>
+      )}
+
+      <div
+        className="znc"
+        dangerouslySetInnerHTML={{ __html: post.contentHtml }}
+      />
+    </div>
+  )
+
+  const pdfPanel = (
+    <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col">
+      <iframe
+        title="論文PDF"
+        src={post.source_url ?? ''}
+        className="min-h-0 w-full flex-1 border-0"
+      />
+    </div>
+  )
+
+  // Mobile: a single column with the chat as a third tab. The side-by-side
+  // resizable split is unusable below ~768px.
+  if (isMobile) {
+    return (
+      <div className="h-svh overflow-hidden">
+        <Tabs
+          defaultValue="blog"
+          className="flex h-full min-h-0 flex-col gap-3 px-4 pb-2 pt-3"
+        >
+          <TabsList
+            variant="line"
+            className="h-9 w-full shrink-0 justify-start pl-10"
+          >
+            <TabsTrigger value="blog">ブログ</TabsTrigger>
+            <TabsTrigger value="pdf">PDF</TabsTrigger>
+            <TabsTrigger value="chat">アシスタント</TabsTrigger>
+          </TabsList>
+
+          <TabsContent
+            value="blog"
+            className="mt-0 min-h-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
+          >
+            {blogPanel}
+          </TabsContent>
+
+          <TabsContent
+            value="pdf"
+            className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
+          >
+            {pdfPanel}
+          </TabsContent>
+
+          <TabsContent
+            value="chat"
+            className="mt-0 -mx-4 flex min-h-0 flex-1 flex-col overflow-hidden border-t border-border/40 data-[state=inactive]:hidden"
+          >
+            <BlogPaperChat paperId={paperId} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-screen overflow-hidden">
+      <ResizablePanelGroup orientation="horizontal">
+        <ResizablePanel defaultSize={62} minSize={30}>
+          <div className="flex h-full min-h-0 flex-col px-4 py-8">
+            <Tabs
+              defaultValue="blog"
+              className="flex min-h-0 flex-1 flex-col gap-4"
+            >
+              <TabsList
+                variant="line"
+                className="h-9 w-full max-w-md shrink-0 justify-start"
+              >
+                <TabsTrigger value="blog">ブログ</TabsTrigger>
+                <TabsTrigger value="pdf">PDF</TabsTrigger>
+              </TabsList>
+
+              <TabsContent
+                value="blog"
+                className="mt-0 min-h-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
+              >
+                {blogPanel}
+              </TabsContent>
+
+              <TabsContent
+                value="pdf"
+                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
+              >
+                {pdfPanel}
+              </TabsContent>
+            </Tabs>
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <ResizablePanel
+          defaultSize={38}
+          minSize={20}
+          className="min-h-0 overflow-hidden"
+        >
+          <BlogPaperChat paperId={paperId} />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  )
+}

--- a/frontend/app/components/figure-suggestion/figure-lightbox.tsx
+++ b/frontend/app/components/figure-suggestion/figure-lightbox.tsx
@@ -46,7 +46,7 @@ export function FigureLightbox({ item, onClose }: FigureLightboxProps) {
             )}
 
             <Link
-              to={blogPostPath(item.paper_id)}
+              to={blogPostPath(item.paper_id, item.source_type)}
               className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline"
             >
               <ExternalLinkIcon className="size-3.5" />

--- a/frontend/app/components/figure-suggestion/figure-lightbox.tsx
+++ b/frontend/app/components/figure-suggestion/figure-lightbox.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from '~/components/ui/dialog'
 import type { FigureSuggestionItem } from '~/hooks/use-figure-suggestion'
+import { blogPostPath } from '~/lib/blog-path'
 
 type FigureLightboxProps = {
   item: FigureSuggestionItem | null
@@ -45,7 +46,7 @@ export function FigureLightbox({ item, onClose }: FigureLightboxProps) {
             )}
 
             <Link
-              to={`/blog/${item.paper_id}`}
+              to={blogPostPath(item.paper_id)}
               className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline"
             >
               <ExternalLinkIcon className="size-3.5" />

--- a/frontend/app/lib/blog-path.ts
+++ b/frontend/app/lib/blog-path.ts
@@ -1,0 +1,7 @@
+// ブログ記事の遷移先パス。PDF由来の記事（paper_idが`pdf-`接頭）は認証が必要な
+// 専用ルートへ、arXiv記事はSSR対応の公開ルートへ振り分ける。
+export function blogPostPath(paperId: string): string {
+  return paperId.startsWith('pdf-')
+    ? `/blog/pdf/${paperId}`
+    : `/blog/${paperId}`
+}

--- a/frontend/app/lib/blog-path.ts
+++ b/frontend/app/lib/blog-path.ts
@@ -1,7 +1,13 @@
-// ブログ記事の遷移先パス。PDF由来の記事（paper_idが`pdf-`接頭）は認証が必要な
-// 専用ルートへ、arXiv記事はSSR対応の公開ルートへ振り分ける。
-export function blogPostPath(paperId: string): string {
-  return paperId.startsWith('pdf-')
-    ? `/blog/pdf/${paperId}`
-    : `/blog/${paperId}`
+import type { BlogPostResponseSchema } from '~/api/types.gen'
+
+type BlogSourceType = BlogPostResponseSchema['source_type']
+
+// ブログ記事の遷移先パス。PDF由来の記事は認証が必要な専用ルートへ、arXiv記事は
+// SSR対応の公開ルートへ振り分ける。種別はbackendの`source_type`で判定する
+// （paper_idの形式に依存しないため、ID形式が変わっても壊れない）。
+export function blogPostPath(
+  paperId: string,
+  sourceType: BlogSourceType,
+): string {
+  return sourceType === 'pdf' ? `/blog/pdf/${paperId}` : `/blog/${paperId}`
 }

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -10,6 +10,7 @@ export default [
     index('routes/arxiv.tsx'),
     route('pdf', 'routes/pdf.tsx'),
     route('blog', 'routes/blog.tsx'),
+    route('blog/pdf/:paperId', 'routes/blog.pdf.$paperId.tsx'),
     route('blog/:paperId', 'routes/blog.$paperId.tsx'),
     route('figures', 'routes/figures.tsx'),
     route('my-blogs', 'routes/my-blogs.tsx'),

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -1,4 +1,5 @@
 import markdownToHtml from 'zenn-markdown-html'
+import { BookOpenIcon } from 'lucide-react'
 import { useEffect } from 'react'
 import { useParams } from 'react-router'
 import { BlogPaperChat } from '~/components/blog-paper-chat'
@@ -10,16 +11,53 @@ import {
 } from '~/components/ui/resizable'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
+import type { BlogPostResponseSchema } from '~/api/types.gen'
 import type { Route } from './+types/blog.$paperId'
 
 const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
 
+// 本文Markdownをレンダリングして表示用データに整形する。loader（サーバー）と
+// clientLoader（ブラウザ）の双方から利用する。
+async function toBlogPost(data: BlogPostResponseSchema) {
+  return {
+    ...data,
+    contentHtml: await markdownToHtml(data.content),
+    requiresAuth: false as const,
+  }
+}
+
 // サーバーサイドでデータを取得することで、初期HTMLに本文とメタ情報が
-// 含まれるようにする（SEO / OGP 対応）。公開記事のため認証は不要なので、
-// ベースURLを明示して既定クライアントの認証コールバックに依存しない。
+// 含まれるようにする（SEO / OGP 対応）。公開記事（arXiv）はこの経路で
+// SSR される。一方で非公開記事（PDF）はバックエンドがオーナーの Bearer
+// トークン付きリクエストにのみ 200 を返すため、セッションを持たない
+// サーバーでは 404 になる。その場合は例外を投げず requiresAuth センチネルを
+// 返し、ブラウザ側の clientLoader がユーザーの認証付きで再取得する。
 export async function loader({ params }: Route.LoaderArgs) {
-  const { data, error } = await getBlogApiV1BlogPaperIdGet({
+  const { data, response } = await getBlogApiV1BlogPaperIdGet({
     baseUrl: import.meta.env.VITE_API_BASE_URL,
+    path: { paper_id: params.paperId! },
+    throwOnError: false,
+  })
+  if (data) return toBlogPost(data)
+  // 404 は「存在しない」と「非公開（オーナー限定）」を区別できないため、
+  // ブラウザ側で認証付き再取得に委ねる。それ以外は本当のエラー。
+  if (response.status === 404) return { requiresAuth: true as const }
+  throw new Response('Failed to load blog post', {
+    status: response.status || 500,
+  })
+}
+
+// ブラウザ側ではユーザーの Supabase セッションを注入する既定クライアントで
+// 取得する。公開記事はサーバーで取得済みなので、その結果をそのまま使う。
+export async function clientLoader({
+  serverLoader,
+  params,
+}: Route.ClientLoaderArgs) {
+  const serverData = await serverLoader()
+  if (!serverData.requiresAuth) return serverData
+
+  // 非公開記事（PDF）: オーナーの認証付きで再取得する。
+  const { data, error } = await getBlogApiV1BlogPaperIdGet({
     path: { paper_id: params.paperId! },
     throwOnError: false,
   })
@@ -27,14 +65,14 @@ export async function loader({ params }: Route.LoaderArgs) {
     throw new Response('Blog post not found', {
       status: error ? 404 : 500,
     })
-  return {
-    ...data,
-    contentHtml: await markdownToHtml(data.content),
-  }
+  return toBlogPost(data)
 }
+clientLoader.hydrate = true as const
 
 export function meta({ loaderData, location }: Route.MetaArgs) {
-  if (!loaderData) return [{ title: 'Blog Post | jaXiv' }]
+  // データ未取得、または非公開記事（SEO 不要）の場合は汎用タイトルのみ。
+  if (!loaderData || loaderData.requiresAuth)
+    return [{ title: 'Blog Post | jaXiv' }]
 
   const url = `${SITE_ORIGIN}${location.pathname}`
   const title = `${loaderData.title} | jaXiv`
@@ -81,6 +119,23 @@ export default function BlogPage({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
     import('zenn-embed-elements')
   }, [])
+
+  // 非公開記事（PDF）はサーバーでは取得できず、ハイドレーション後に
+  // clientLoader が認証付きで再取得する。その間のフォールバック表示。
+  if (loaderData.requiresAuth) {
+    return (
+      <main
+        className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center px-4 py-8"
+        aria-busy="true"
+      >
+        <p className="sr-only">読み込み中</p>
+        <BookOpenIcon
+          className="size-14 shrink-0 text-muted-foreground animate-pulse"
+          aria-hidden
+        />
+      </main>
+    )
+  }
 
   const blogPanel = (
     <div className="mx-auto max-w-3xl">

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -1,5 +1,4 @@
 import markdownToHtml from 'zenn-markdown-html'
-import { BookOpenIcon } from 'lucide-react'
 import { useEffect } from 'react'
 import { useParams } from 'react-router'
 import { BlogPaperChat } from '~/components/blog-paper-chat'
@@ -13,8 +12,14 @@ import { useIsMobile } from '~/hooks/use-mobile'
 import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
 import type { Route } from './+types/blog.$paperId'
 
-export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
+
+// サーバーサイドでデータを取得することで、初期HTMLに本文とメタ情報が
+// 含まれるようにする（SEO / OGP 対応）。公開記事のため認証は不要なので、
+// ベースURLを明示して既定クライアントの認証コールバックに依存しない。
+export async function loader({ params }: Route.LoaderArgs) {
   const { data, error } = await getBlogApiV1BlogPaperIdGet({
+    baseUrl: import.meta.env.VITE_API_BASE_URL,
     path: { paper_id: params.paperId! },
     throwOnError: false,
   })
@@ -28,26 +33,44 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   }
 }
 
-export function HydrateFallback() {
-  return (
-    <main
-      className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center px-4 py-8"
-      aria-busy="true"
-    >
-      <p className="sr-only">読み込み中</p>
-      <BookOpenIcon
-        className="size-14 shrink-0 text-muted-foreground animate-pulse"
-        aria-hidden
-      />
-    </main>
-  )
-}
-
-export function meta({ loaderData }: Route.MetaArgs) {
+export function meta({ loaderData, location }: Route.MetaArgs) {
   if (!loaderData) return [{ title: 'Blog Post | jaXiv' }]
+
+  const url = `${SITE_ORIGIN}${location.pathname}`
+  const title = `${loaderData.title} | jaXiv`
+  const description = loaderData.summary
+
   return [
-    { title: loaderData.title },
-    { name: 'description', content: loaderData.summary },
+    { title },
+    { name: 'description', content: description },
+    // Open Graph
+    { property: 'og:type', content: 'article' },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: url },
+    { property: 'og:site_name', content: 'jaXiv' },
+    // Twitter Card
+    { name: 'twitter:card', content: 'summary_large_image' },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
+    // 正規URL
+    { tagName: 'link', rel: 'canonical', href: url },
+    // 構造化データ（学術記事）
+    {
+      'script:ld+json': {
+        '@context': 'https://schema.org',
+        '@type': 'ScholarlyArticle',
+        headline: loaderData.title,
+        abstract: description,
+        inLanguage: 'ja',
+        author:
+          loaderData.authors.length > 0
+            ? loaderData.authors.map(name => ({ '@type': 'Person', name }))
+            : undefined,
+        url,
+        sameAs: loaderData.source_url ?? undefined,
+      },
+    },
   ]
 }
 

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -1,5 +1,4 @@
 import markdownToHtml from 'zenn-markdown-html'
-import { redirect } from 'react-router'
 import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
 import { BlogPostView } from '~/components/blog/blog-post-view'
 import type { Route } from './+types/blog.$paperId'
@@ -7,13 +6,9 @@ import type { Route } from './+types/blog.$paperId'
 const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
 
 // arXiv記事（公開）用ルート。サーバーサイドで取得して初期HTMLに本文と
-// メタ情報を含めることで SEO / OGP に対応する。PDF記事（非公開）はオーナーの
-// 認証が必要なため、専用ルート `/blog/pdf/:paperId` にリダイレクトする。
+// メタ情報を含めることで SEO / OGP に対応する。PDF記事（非公開）は認証が必要な
+// 専用ルート `/blog/pdf/:paperId` で扱い、遷移リンクは `source_type` で振り分ける。
 export async function loader({ params }: Route.LoaderArgs) {
-  if (params.paperId.startsWith('pdf-')) {
-    throw redirect(`/blog/pdf/${params.paperId}`)
-  }
-
   const { data, error } = await getBlogApiV1BlogPaperIdGet({
     baseUrl: import.meta.env.VITE_API_BASE_URL,
     path: { paper_id: params.paperId },

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -1,78 +1,36 @@
 import markdownToHtml from 'zenn-markdown-html'
-import { BookOpenIcon } from 'lucide-react'
-import { useEffect } from 'react'
-import { useParams } from 'react-router'
-import { BlogPaperChat } from '~/components/blog-paper-chat'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from '~/components/ui/resizable'
-import { useIsMobile } from '~/hooks/use-mobile'
+import { redirect } from 'react-router'
 import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
-import type { BlogPostResponseSchema } from '~/api/types.gen'
+import { BlogPostView } from '~/components/blog/blog-post-view'
 import type { Route } from './+types/blog.$paperId'
 
 const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
 
-// 本文Markdownをレンダリングして表示用データに整形する。loader（サーバー）と
-// clientLoader（ブラウザ）の双方から利用する。
-async function toBlogPost(data: BlogPostResponseSchema) {
-  return {
-    ...data,
-    contentHtml: await markdownToHtml(data.content),
-    requiresAuth: false as const,
-  }
-}
-
-// サーバーサイドでデータを取得することで、初期HTMLに本文とメタ情報が
-// 含まれるようにする（SEO / OGP 対応）。公開記事（arXiv）はこの経路で
-// SSR される。一方で非公開記事（PDF）はバックエンドがオーナーの Bearer
-// トークン付きリクエストにのみ 200 を返すため、セッションを持たない
-// サーバーでは 404 になる。その場合は例外を投げず requiresAuth センチネルを
-// 返し、ブラウザ側の clientLoader がユーザーの認証付きで再取得する。
+// arXiv記事（公開）用ルート。サーバーサイドで取得して初期HTMLに本文と
+// メタ情報を含めることで SEO / OGP に対応する。PDF記事（非公開）はオーナーの
+// 認証が必要なため、専用ルート `/blog/pdf/:paperId` にリダイレクトする。
 export async function loader({ params }: Route.LoaderArgs) {
-  const { data, response } = await getBlogApiV1BlogPaperIdGet({
-    baseUrl: import.meta.env.VITE_API_BASE_URL,
-    path: { paper_id: params.paperId! },
-    throwOnError: false,
-  })
-  if (data) return toBlogPost(data)
-  // 404 は「存在しない」と「非公開（オーナー限定）」を区別できないため、
-  // ブラウザ側で認証付き再取得に委ねる。それ以外は本当のエラー。
-  if (response.status === 404) return { requiresAuth: true as const }
-  throw new Response('Failed to load blog post', {
-    status: response.status || 500,
-  })
-}
+  if (params.paperId.startsWith('pdf-')) {
+    throw redirect(`/blog/pdf/${params.paperId}`)
+  }
 
-// ブラウザ側ではユーザーの Supabase セッションを注入する既定クライアントで
-// 取得する。公開記事はサーバーで取得済みなので、その結果をそのまま使う。
-export async function clientLoader({
-  serverLoader,
-  params,
-}: Route.ClientLoaderArgs) {
-  const serverData = await serverLoader()
-  if (!serverData.requiresAuth) return serverData
-
-  // 非公開記事（PDF）: オーナーの認証付きで再取得する。
   const { data, error } = await getBlogApiV1BlogPaperIdGet({
-    path: { paper_id: params.paperId! },
+    baseUrl: import.meta.env.VITE_API_BASE_URL,
+    path: { paper_id: params.paperId },
     throwOnError: false,
   })
   if (!data)
     throw new Response('Blog post not found', {
       status: error ? 404 : 500,
     })
-  return toBlogPost(data)
+  return {
+    ...data,
+    contentHtml: await markdownToHtml(data.content),
+  }
 }
-clientLoader.hydrate = true as const
 
 export function meta({ loaderData, location }: Route.MetaArgs) {
-  // データ未取得、または非公開記事（SEO 不要）の場合は汎用タイトルのみ。
-  if (!loaderData || loaderData.requiresAuth)
-    return [{ title: 'Blog Post | jaXiv' }]
+  if (!loaderData) return [{ title: 'Blog Post | jaXiv' }]
 
   const url = `${SITE_ORIGIN}${location.pathname}`
   const title = `${loaderData.title} | jaXiv`
@@ -112,157 +70,6 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
   ]
 }
 
-export default function BlogPage({ loaderData }: Route.ComponentProps) {
-  const { paperId } = useParams()
-  const isMobile = useIsMobile()
-
-  useEffect(() => {
-    import('zenn-embed-elements')
-  }, [])
-
-  // 非公開記事（PDF）はサーバーでは取得できず、ハイドレーション後に
-  // clientLoader が認証付きで再取得する。その間のフォールバック表示。
-  if (loaderData.requiresAuth) {
-    return (
-      <main
-        className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center px-4 py-8"
-        aria-busy="true"
-      >
-        <p className="sr-only">読み込み中</p>
-        <BookOpenIcon
-          className="size-14 shrink-0 text-muted-foreground animate-pulse"
-          aria-hidden
-        />
-      </main>
-    )
-  }
-
-  const blogPanel = (
-    <div className="mx-auto max-w-3xl">
-      {(loaderData.authors.length > 0 || loaderData.source_url) && (
-        <header className="mb-8 space-y-2">
-          {loaderData.authors.length > 0 && (
-            <p className="text-sm text-muted-foreground">
-              {loaderData.authors.join(', ')}
-            </p>
-          )}
-          {loaderData.source_url && (
-            <a
-              href={loaderData.source_url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-sm text-primary hover:underline"
-            >
-              {loaderData.source_url}
-            </a>
-          )}
-        </header>
-      )}
-
-      <div
-        className="znc"
-        dangerouslySetInnerHTML={{ __html: loaderData.contentHtml }}
-      />
-    </div>
-  )
-
-  const pdfPanel = (
-    <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col">
-      <iframe
-        title="論文PDF"
-        src={loaderData.source_url ?? ''}
-        className="min-h-0 w-full flex-1 border-0"
-      />
-    </div>
-  )
-
-  // Mobile: a single column with the chat as a third tab. The side-by-side
-  // resizable split is unusable below ~768px.
-  if (isMobile) {
-    return (
-      <div className="h-svh overflow-hidden">
-        <Tabs
-          defaultValue="blog"
-          className="flex h-full min-h-0 flex-col gap-3 px-4 pb-2 pt-3"
-        >
-          <TabsList
-            variant="line"
-            className="h-9 w-full shrink-0 justify-start pl-10"
-          >
-            <TabsTrigger value="blog">ブログ</TabsTrigger>
-            <TabsTrigger value="pdf">PDF</TabsTrigger>
-            <TabsTrigger value="chat">アシスタント</TabsTrigger>
-          </TabsList>
-
-          <TabsContent
-            value="blog"
-            className="mt-0 min-h-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
-          >
-            {blogPanel}
-          </TabsContent>
-
-          <TabsContent
-            value="pdf"
-            className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
-          >
-            {pdfPanel}
-          </TabsContent>
-
-          <TabsContent
-            value="chat"
-            className="mt-0 -mx-4 flex min-h-0 flex-1 flex-col overflow-hidden border-t border-border/40 data-[state=inactive]:hidden"
-          >
-            {paperId ? <BlogPaperChat paperId={paperId} /> : null}
-          </TabsContent>
-        </Tabs>
-      </div>
-    )
-  }
-
-  return (
-    <div className="h-screen overflow-hidden">
-      <ResizablePanelGroup orientation="horizontal">
-        <ResizablePanel defaultSize={62} minSize={30}>
-          <div className="flex h-full min-h-0 flex-col px-4 py-8">
-            <Tabs
-              defaultValue="blog"
-              className="flex min-h-0 flex-1 flex-col gap-4"
-            >
-              <TabsList
-                variant="line"
-                className="h-9 w-full max-w-md shrink-0 justify-start"
-              >
-                <TabsTrigger value="blog">ブログ</TabsTrigger>
-                <TabsTrigger value="pdf">PDF</TabsTrigger>
-              </TabsList>
-
-              <TabsContent
-                value="blog"
-                className="mt-0 min-h-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
-              >
-                {blogPanel}
-              </TabsContent>
-
-              <TabsContent
-                value="pdf"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
-              >
-                {pdfPanel}
-              </TabsContent>
-            </Tabs>
-          </div>
-        </ResizablePanel>
-
-        <ResizableHandle withHandle />
-
-        <ResizablePanel
-          defaultSize={38}
-          minSize={20}
-          className="min-h-0 overflow-hidden"
-        >
-          {paperId ? <BlogPaperChat paperId={paperId} /> : null}
-        </ResizablePanel>
-      </ResizablePanelGroup>
-    </div>
-  )
+export default function BlogPage({ loaderData, params }: Route.ComponentProps) {
+  return <BlogPostView post={loaderData} paperId={params.paperId} />
 }

--- a/frontend/app/routes/blog.pdf.$paperId.tsx
+++ b/frontend/app/routes/blog.pdf.$paperId.tsx
@@ -1,0 +1,55 @@
+import markdownToHtml from 'zenn-markdown-html'
+import { BookOpenIcon } from 'lucide-react'
+import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
+import { BlogPostView } from '~/components/blog/blog-post-view'
+import type { Route } from './+types/blog.pdf.$paperId'
+
+// PDF記事（非公開）用ルート。バックエンドはオーナーの Bearer トークン付き
+// リクエストにのみ 200 を返すため、ブラウザ側でユーザーの Supabase セッションを
+// 注入する既定クライアントを使って取得する（SEO は不要）。
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  const { data, error } = await getBlogApiV1BlogPaperIdGet({
+    path: { paper_id: params.paperId },
+    throwOnError: false,
+  })
+  if (!data)
+    throw new Response('Blog post not found', {
+      status: error ? 404 : 500,
+    })
+  return {
+    ...data,
+    contentHtml: await markdownToHtml(data.content),
+  }
+}
+
+export function HydrateFallback() {
+  return (
+    <main
+      className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center px-4 py-8"
+      aria-busy="true"
+    >
+      <p className="sr-only">読み込み中</p>
+      <BookOpenIcon
+        className="size-14 shrink-0 text-muted-foreground animate-pulse"
+        aria-hidden
+      />
+    </main>
+  )
+}
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  if (!loaderData) return [{ title: 'Blog Post | jaXiv' }]
+  return [
+    { title: `${loaderData.title} | jaXiv` },
+    { name: 'description', content: loaderData.summary },
+    // 非公開記事のためクローラーには公開しない。
+    { name: 'robots', content: 'noindex' },
+  ]
+}
+
+export default function PdfBlogPage({
+  loaderData,
+  params,
+}: Route.ComponentProps) {
+  return <BlogPostView post={loaderData} paperId={params.paperId} />
+}

--- a/frontend/app/routes/pdf.tsx
+++ b/frontend/app/routes/pdf.tsx
@@ -27,7 +27,7 @@ export default function Pdf() {
 
   useEffect(() => {
     if (status === 'complete' && paperId) {
-      navigate(blogPostPath(paperId))
+      navigate(blogPostPath(paperId, 'pdf'))
     }
   }, [status, paperId, navigate])
 

--- a/frontend/app/routes/pdf.tsx
+++ b/frontend/app/routes/pdf.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router'
 import { ArrowRightIcon, FileUpIcon } from 'lucide-react'
 
 import { useAuth } from '~/contexts/auth-context'
+import { blogPostPath } from '~/lib/blog-path'
 import { useBlogStream } from '../hooks/use-blog-stream'
 import { GenerationHero } from '../components/generation-hero'
 import { GenerationSteps } from '../components/generation-steps'
@@ -26,7 +27,7 @@ export default function Pdf() {
 
   useEffect(() => {
     if (status === 'complete' && paperId) {
-      navigate(`/blog/${paperId}`)
+      navigate(blogPostPath(paperId))
     }
   }, [status, paperId, navigate])
 


### PR DESCRIPTION
## 概要

ブログ記事ページ（`frontend/app/routes/blog.$paperId.tsx`）にSEO / OGP対応を追加します。

これまで記事データはクライアントサイドの `clientLoader` で取得していたため、初期HTMLに本文・メタ情報が含まれず、検索エンジンやSNSのクローラーにコンテンツが届きませんでした。サーバーサイドの `loader` に変更し、初期HTMLに本文とメタ情報を含めることでSEO / OGPに対応します。

## 変更内容

- `clientLoader` → サーバー `loader` へ変更
  - SSRは有効（`react-router.config.ts` の `ssr: true`）。公開記事のため認証不要なので、`baseUrl` を明示して既定クライアントの認証コールバックに依存しないようにする
- `meta` を拡充し、以下のメタ情報を出力
  - Open Graph（`og:type` / `og:title` / `og:description` / `og:url` / `og:site_name`）
  - Twitter Card（`summary_large_image`）
  - canonical リンク
  - 構造化データ JSON-LD（`ScholarlyArticle`：著者・要約・言語・元論文URLなど）
- クライアントローダー化に伴い不要となった `HydrateFallback` と `BookOpenIcon` import を削除

## 確認事項

- `npm run typecheck`（`react-router typegen && tsc`）: パス
- `eslint`（対象ファイル）: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DErPv6UzZQyijkYgfe95Lm)_