### PR TITLE
feat(frontend): 図面検索UI改善とNomic埋め込みのスレッドセーフ化

### DIFF
--- a/frontend/app/components/figure-suggestion/figure-search-composer.tsx
+++ b/frontend/app/components/figure-suggestion/figure-search-composer.tsx
@@ -1,6 +1,7 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { LightbulbIcon, SearchIcon } from 'lucide-react'
 
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -51,11 +52,11 @@ export function FigureSearchComposer({
   }
 
   return (
-    <div className="flex w-full max-w-3xl flex-col gap-3">
+    <div className="flex w-full max-w-3xl flex-col gap-3.5">
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
-          className="rounded-xl border border-border bg-card p-4 shadow-sm"
+          className="rounded-2xl border border-border/80 bg-white/90 shadow-lg shadow-indigo-100/40 backdrop-blur-sm transition-[border-color,box-shadow] focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/15 dark:bg-card/90 dark:shadow-none"
         >
           <FormField
             control={form.control}
@@ -67,32 +68,58 @@ export function FigureSearchComposer({
                     placeholder="例: グラフニューラルネットワークで分子の性質を予測する手法の全体像を示す図がほしい"
                     rows={3}
                     disabled={isLoading || disabled}
-                    className="resize-none"
+                    className="resize-none border-0 bg-transparent px-4 pt-4 pb-1 text-sm shadow-none focus-visible:ring-0 sm:text-base dark:bg-transparent"
+                    onKeyDown={event => {
+                      // Enter で送信、Shift+Enter で改行。IME 変換確定の Enter は無視する
+                      if (
+                        event.key === 'Enter' &&
+                        !event.shiftKey &&
+                        !event.nativeEvent.isComposing
+                      ) {
+                        event.preventDefault()
+                        form.handleSubmit(handleSubmit)()
+                      }
+                    }}
                     {...field}
                   />
                 </FormControl>
-                <FormMessage />
+                <FormMessage className="px-4 pt-1 text-xs" />
               </FormItem>
             )}
           />
 
-          <Button
-            type="submit"
-            disabled={isLoading || disabled}
-            className="mt-3 w-full sm:w-44"
-          >
-            {isLoading ? '検索中...' : '図を探す'}
-          </Button>
+          <div className="flex items-center justify-between gap-3 px-3 pb-3 pt-1">
+            <p className="hidden text-xs text-muted-foreground sm:block">
+              Enter で検索 / Shift + Enter で改行
+            </p>
+            <Button
+              type="submit"
+              size="icon"
+              aria-label="図を探す"
+              disabled={isLoading || disabled}
+              className="ml-auto size-10 rounded-full"
+            >
+              {isLoading ? (
+                <span className="inline-block size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              ) : (
+                <SearchIcon className="size-4" />
+              )}
+            </Button>
+          </div>
         </form>
       </Form>
 
       <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
+          <LightbulbIcon className="size-3.5" />
+          例:
+        </span>
         {EXAMPLE_PROMPTS.map(prompt => (
           <Badge
             key={prompt}
             variant="outline"
             asChild
-            className="cursor-pointer bg-muted/40 px-3 py-1 text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+            className="cursor-pointer rounded-full border-border/70 bg-white/60 px-3 py-1 font-normal text-muted-foreground backdrop-blur-sm transition-colors hover:border-primary/50 hover:bg-primary/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:bg-card/60"
           >
             <button
               type="button"

--- a/frontend/app/routes/figures.tsx
+++ b/frontend/app/routes/figures.tsx
@@ -24,7 +24,7 @@ export function meta() {
 }
 
 export default function Figures() {
-  const { isAnonymous } = useAuth()
+  const { isAnonymous, signInWithGoogle } = useAuth()
   const { items, error, submitted, isPending, submit } = useFigureSuggestion()
   const [selected, setSelected] = useState<FigureSuggestionItem | null>(null)
 
@@ -50,6 +50,20 @@ export default function Figures() {
             onSubmit={submit}
           />
 
+          {isAnonymous && (
+            <p className="mt-3 text-sm text-muted-foreground">
+              図面検索を利用するには
+              <button
+                type="button"
+                onClick={signInWithGoogle}
+                className="mx-1 cursor-pointer font-semibold text-primary underline underline-offset-2"
+              >
+                Googleでログイン
+              </button>
+              してください。
+            </p>
+          )}
+
           {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
         </div>
       </GenerationHero>
@@ -60,6 +74,16 @@ export default function Figures() {
             <FigureGallery items={[]} isLoading onSelect={setSelected} />
           ) : (
             <div className="flex flex-col gap-5">
+              <div className="flex items-baseline justify-between">
+                <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">
+                  検索結果
+                </h2>
+                {items.length > 0 && (
+                  <span className="text-sm text-muted-foreground">
+                    {items.length}件
+                  </span>
+                )}
+              </div>
               <FigureQueryChips queries={queries} />
               <FigureGallery
                 items={items}

--- a/pdf_analysis/infrastructure/nomic/text_embedding.py
+++ b/pdf_analysis/infrastructure/nomic/text_embedding.py
@@ -1,3 +1,5 @@
+import threading
+
 import torch
 import torch.nn.functional as F
 from transformers import AutoModel, AutoTokenizer
@@ -10,6 +12,10 @@ class NomicTextEmbeddingGateway(TextEmbeddingGateway):
     def __init__(self, model: AutoModel, tokenizer: AutoTokenizer) -> None:
         self._model = model
         self._tokenizer = tokenizer
+        # nomic-bert の custom modeling は forward 中に rotary embedding の
+        # cos/sin キャッシュをシーケンス長に応じて書き換えるためスレッドセーフでない。
+        # FastAPI の同期エンドポイントはスレッドプールで並行実行されるので直列化する
+        self._lock = threading.Lock()
 
     def embed_text_batch(self, texts: list[str]) -> list[Embedding]:
         # nomic-embed-text requires task prefix for document embedding
@@ -25,7 +31,7 @@ class NomicTextEmbeddingGateway(TextEmbeddingGateway):
         encoded = self._tokenizer(
             prefixed, padding=True, truncation=True, return_tensors="pt"
         )
-        with torch.no_grad():
+        with self._lock, torch.no_grad():
             output = self._model(**encoded)
         token_emb = output.last_hidden_state
         mask = encoded["attention_mask"].unsqueeze(-1).expand(token_emb.size()).float()


### PR DESCRIPTION
## Summary
- 図面検索の入力体験をチャットUI風に刷新し、Enterで検索・Shift+Enterで改行できるようにして操作感を向上
- 匿名ユーザーが機能を利用する前にGoogleログインへ誘導できるよう、ログイン導線を追加
- Nomic埋め込みモデルがFastAPIのスレッドプール並行実行で競合する問題をLockで防止し、安定性を改善

## Changes
- `frontend/app/components/figure-suggestion/figure-search-composer.tsx` — チャット風デザイン、Enter送信、丸型検索ボタン、例プロンプトのUI改善
- `frontend/app/routes/figures.tsx` — 匿名ユーザー向けGoogleログイン導線、検索結果件数ヘッダー追加
- `pdf_analysis/infrastructure/nomic/text_embedding.py` — `threading.Lock` による埋め込み推論の直列化

## Test plan
- [ ] `/figures` ページで検索composerの見た目がチャットUI風になっていることを確認
- [ ] Enterで検索が実行され、Shift+Enterで改行できることを確認（IME変換確定のEnterは送信されないこと）
- [ ] 未ログイン状態で「Googleでログイン」リンクが表示され、クリックで認証フローが開始されること
- [ ] 検索実行後、「検索結果」ヘッダーと件数が表示されること
- [ ] pdf_analysisサービスで並行リクエスト時に埋め込み推論がエラーなく完了すること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Made with [Cursor](https://cursor.com)