### PR TITLE
Fix "Already borrowed" ASGI crash in embedding gateways

### DIFF
--- a/pdf_analysis/infrastructure/bge/text_embedding.py
+++ b/pdf_analysis/infrastructure/bge/text_embedding.py
@@ -1,3 +1,5 @@
+import threading
+
 import torch
 import torch.nn.functional as F
 from transformers import AutoModel, AutoTokenizer
@@ -10,12 +12,15 @@ class BgeTextEmbeddingGateway(TextEmbeddingGateway):
     def __init__(self, model: AutoModel, tokenizer: AutoTokenizer) -> None:
         self._model = model
         self._tokenizer = tokenizer
+        # 高速トークナイザ(Rust実装)とmodel.forwardは内部状態を持ち並行呼び出しに
+        # 耐えないため、FastAPIのスレッドプール実行に合わせて直列化する
+        self._lock = threading.Lock()
 
     def embed_text_batch(self, texts: list[str]) -> list[Embedding]:
-        encoded = self._tokenizer(
-            texts, padding=True, truncation=True, return_tensors="pt"
-        )
-        with torch.no_grad():
+        with self._lock, torch.no_grad():
+            encoded = self._tokenizer(
+                texts, padding=True, truncation=True, return_tensors="pt"
+            )
             output = self._model(**encoded)
         # BGE uses CLS token pooling
         embeddings = F.normalize(output.last_hidden_state[:, 0], p=2, dim=1)

--- a/pdf_analysis/infrastructure/nomic/text_embedding.py
+++ b/pdf_analysis/infrastructure/nomic/text_embedding.py
@@ -14,6 +14,8 @@ class NomicTextEmbeddingGateway(TextEmbeddingGateway):
         self._tokenizer = tokenizer
         # nomic-bert の custom modeling は forward 中に rotary embedding の
         # cos/sin キャッシュをシーケンス長に応じて書き換えるためスレッドセーフでない。
+        # 高速トークナイザ(Rust実装)も内部状態を持ち並行呼び出しに耐えないため
+        # 同じロックでトークナイズとforwardの両方を直列化する。
         # FastAPI の同期エンドポイントはスレッドプールで並行実行されるので直列化する
         self._lock = threading.Lock()
 
@@ -28,10 +30,10 @@ class NomicTextEmbeddingGateway(TextEmbeddingGateway):
         return self._embed_prefixed(prefixed)
 
     def _embed_prefixed(self, prefixed: list[str]) -> list[Embedding]:
-        encoded = self._tokenizer(
-            prefixed, padding=True, truncation=True, return_tensors="pt"
-        )
         with self._lock, torch.no_grad():
+            encoded = self._tokenizer(
+                prefixed, padding=True, truncation=True, return_tensors="pt"
+            )
             output = self._model(**encoded)
         token_emb = output.last_hidden_state
         mask = encoded["attention_mask"].unsqueeze(-1).expand(token_emb.size()).float()


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: Already borrowed` crashes in `pdf_analysis` embedding endpoints, seen in the ASGI traceback at `/embed/query`.
- Root cause: the HuggingFace fast tokenizer (Rust-backed) is not safe to call concurrently across threads. FastAPI runs sync endpoints in a thread pool, so overlapping `/embed` requests could call the tokenizer at the same time and hit an internal `RefCell` re-entrancy panic inside the `tokenizers` crate, surfacing as "Already borrowed".
- `pdf_analysis/infrastructure/nomic/text_embedding.py`: the tokenizer call was outside the existing `self._lock`, while the model forward pass was inside it — moved the tokenizer call inside the lock so tokenization and forward are fully serialized.
- `pdf_analysis/infrastructure/bge/text_embedding.py`: had no lock at all around the tokenizer/model calls — added the same `threading.Lock()`-based serialization for consistency and to fix the same class of bug.

## Test plan

- [x] Verified both edited files parse correctly (`ast.parse`)
- [ ] Manually exercise `/embed/query` and `/embed` under concurrent load to confirm no more "Already borrowed" errors (not run in this environment — no way to spin up the full model stack here)


---
_Generated by [Claude Code](https://claude.ai/code/session_014yqXXckMTgKYLJf4yHwq1D)_