### PR TITLE
feat(frontend): ブログ記事のOGPにX共有プレビュー用のog:image/twitter:imageを追加

### DIFF
--- a/frontend/app/lib/blog-content.ts
+++ b/frontend/app/lib/blog-content.ts
@@ -1,0 +1,6 @@
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/
+
+// og:image/twitter:image用に、記事本文Markdown中の最初の図版URLを抽出する。
+export function extractFirstImageUrl(markdown: string): string | undefined {
+  return MARKDOWN_IMAGE_RE.exec(markdown)?.[1]
+}

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -5,6 +5,15 @@ import type { Route } from './+types/blog.$paperId'
 
 const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
 
+// 記事本文（Markdown）中に埋め込まれた最初の図版URLを抽出する。生成時に
+// `![caption](https://...)` 形式で挿入されているため、それをそのまま
+// og:image / twitter:image に使うことでXなどのカードに論文の図が表示される。
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/
+
+function extractFirstImageUrl(markdown: string): string | undefined {
+  return MARKDOWN_IMAGE_RE.exec(markdown)?.[1]
+}
+
 // arXiv記事（公開）用ルート。サーバーサイドで取得して初期HTMLに本文と
 // メタ情報を含めることで SEO / OGP に対応する。PDF記事（非公開）は認証が必要な
 // 専用ルート `/blog/pdf/:paperId` で扱い、遷移リンクは `source_type` で振り分ける。
@@ -21,6 +30,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   return {
     ...data,
     contentHtml: await markdownToHtml(data.content),
+    ogImageUrl: extractFirstImageUrl(data.content),
   }
 }
 
@@ -30,6 +40,7 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
   const url = `${SITE_ORIGIN}${location.pathname}`
   const title = `${loaderData.title} | jaXiv`
   const description = loaderData.summary
+  const imageUrl = loaderData.ogImageUrl
 
   return [
     { title },
@@ -40,10 +51,15 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
     { property: 'og:description', content: description },
     { property: 'og:url', content: url },
     { property: 'og:site_name', content: 'jaXiv' },
+    ...(imageUrl ? [{ property: 'og:image', content: imageUrl }] : []),
     // Twitter Card
-    { name: 'twitter:card', content: 'summary_large_image' },
+    {
+      name: 'twitter:card',
+      content: imageUrl ? 'summary_large_image' : 'summary',
+    },
     { name: 'twitter:title', content: title },
     { name: 'twitter:description', content: description },
+    ...(imageUrl ? [{ name: 'twitter:image', content: imageUrl }] : []),
     // 正規URL
     { tagName: 'link', rel: 'canonical', href: url },
     // 構造化データ（学術記事）
@@ -53,6 +69,7 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
         '@type': 'ScholarlyArticle',
         headline: loaderData.title,
         abstract: description,
+        image: imageUrl ?? undefined,
         inLanguage: 'ja',
         author:
           loaderData.authors.length > 0

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -5,13 +5,20 @@ import type { Route } from './+types/blog.$paperId'
 
 const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
 
-// 記事本文（Markdown）中に埋め込まれた最初の図版URLを抽出する。生成時に
-// `![caption](https://...)` 形式で挿入されているため、それをそのまま
-// og:image / twitter:image に使うことでXなどのカードに論文の図が表示される。
-const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/
+// 記事本文（Markdown）中に埋め込まれた図版URLのうち、OGP/Twitterカードで
+// レンダリング可能な形式の最初の1枚を抽出する。図はarXivのソースからアップ
+// ロードされたものをそのまま使うため、`.eps`/`.svg`のようにXやFacebookの
+// クローラーが画像として展開できない形式が混ざりうる（`.pdf`のみバックエンドで
+// PNGに変換済み）。対応形式以外はスキップし、後続の図にフォールバックする。
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/g
+const SUPPORTED_CARD_IMAGE_EXTENSIONS = /\.(?:png|jpe?g|gif|webp)(?:[?#]|$)/i
 
 function extractFirstImageUrl(markdown: string): string | undefined {
-  return MARKDOWN_IMAGE_RE.exec(markdown)?.[1]
+  const urls = markdown.matchAll(MARKDOWN_IMAGE_RE)
+  for (const [, url] of urls) {
+    if (SUPPORTED_CARD_IMAGE_EXTENSIONS.test(url)) return url
+  }
+  return undefined
 }
 
 // arXiv記事（公開）用ルート。サーバーサイドで取得して初期HTMLに本文と

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -1,25 +1,10 @@
 import markdownToHtml from 'zenn-markdown-html'
 import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
 import { BlogPostView } from '~/components/blog/blog-post-view'
+import { extractFirstImageUrl } from '~/lib/blog-content'
 import type { Route } from './+types/blog.$paperId'
 
 const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
-
-// 記事本文（Markdown）中に埋め込まれた図版URLのうち、OGP/Twitterカードで
-// レンダリング可能な形式の最初の1枚を抽出する。図はarXivのソースからアップ
-// ロードされたものをそのまま使うため、`.eps`/`.svg`のようにXやFacebookの
-// クローラーが画像として展開できない形式が混ざりうる（`.pdf`のみバックエンドで
-// PNGに変換済み）。対応形式以外はスキップし、後続の図にフォールバックする。
-const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/g
-const SUPPORTED_CARD_IMAGE_EXTENSIONS = /\.(?:png|jpe?g|gif|webp)(?:[?#]|$)/i
-
-function extractFirstImageUrl(markdown: string): string | undefined {
-  const urls = markdown.matchAll(MARKDOWN_IMAGE_RE)
-  for (const [, url] of urls) {
-    if (SUPPORTED_CARD_IMAGE_EXTENSIONS.test(url)) return url
-  }
-  return undefined
-}
 
 // arXiv記事（公開）用ルート。サーバーサイドで取得して初期HTMLに本文と
 // メタ情報を含めることで SEO / OGP に対応する。PDF記事（非公開）は認証が必要な


### PR DESCRIPTION
## Summary

- Xなどのリンク共有時に、ブログ記事内の図面（論文の図）がプレビューカードに表示されるようにした
- `blog.$paperId.tsx` のローダーで記事本文Markdown中の最初の図版URL（`[caption](url)`）を正規表現で抽出し、`og:image` / `twitter:image` メタタグとして設定
- 図が無い記事は従来通り `twitter:card` を `summary`（画像なし）にフォールバック
- JSON-LD（`ScholarlyArticle`）にも `image` プロパティを追加

図はブログ生成時にArXivのLaTeXソースからCloudflare R2にアップロードされ、生成されたMarkdown本文中に既に完全修飾のパブリックURLとして埋め込まれているため、バックエンドの変更は不要（`generate_blog_post.py` / `s3_figure_storage_repository.py` を確認）。

PDF由来の非公開記事ルート（`blog.pdf.$paperId.tsx`）は `noindex` のためSEO/OGP対象外であり、今回の対応範囲外とした。

## Test plan

- [x] `npm run typecheck` が通ることを確認
- [x] `npx eslint app/routes/blog.\$paperId.tsx` / `npx prettier --check` が通ることを確認
- [x] 正規表現による画像URL抽出をNodeスクリプトで単体確認（サンプルMarkdownから期待通りURLを抽出）
- [ ] 実際にデプロイ後、X（Twitter）のCard Validator等で図が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6k85rdo7zovjC7nsSkhnV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6k85rdo7zovjC7nsSkhnV)_