### PR TITLE
feat(frontend): ブログのRSSフィード(feed.xml)を追加

### DIFF
--- a/frontend/app/lib/site.ts
+++ b/frontend/app/lib/site.ts
@@ -1,0 +1,3 @@
+// サイトの本番オリジン。SEO用途の絶対URL生成（canonical / OGP / sitemap.xml /
+// feed.xml）で共有する。
+export const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'

--- a/frontend/app/lib/xml.ts
+++ b/frontend/app/lib/xml.ts
@@ -1,0 +1,9 @@
+// XMLの特殊文字をエスケープする。sitemap.xml / feed.xml のリソースルートで共有する。
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -22,6 +22,12 @@ export const links: Route.LinksFunction = () => [
   { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16.png' },
   { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
   { rel: 'manifest', href: '/manifest.json' },
+  {
+    rel: 'alternate',
+    type: 'application/rss+xml',
+    title: 'jaXiv',
+    href: '/feed.xml',
+  },
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
   {
     rel: 'preconnect',

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -24,4 +24,5 @@ export default [
   route('login', 'routes/login.tsx'),
   route('auth/callback', 'routes/auth.callback.tsx'),
   route('sitemap.xml', 'routes/sitemap.xml.ts'),
+  route('feed.xml', 'routes/feed.xml.ts'),
 ] satisfies RouteConfig

--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -2,9 +2,8 @@ import markdownToHtml from 'zenn-markdown-html'
 import { getBlogApiV1BlogPaperIdGet } from '~/api/sdk.gen'
 import { BlogPostView } from '~/components/blog/blog-post-view'
 import { extractFirstImageUrl } from '~/lib/blog-content'
+import { SITE_ORIGIN } from '~/lib/site'
 import type { Route } from './+types/blog.$paperId'
-
-const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
 
 // arXiv記事（公開）用ルート。サーバーサイドで取得して初期HTMLに本文と
 // メタ情報を含めることで SEO / OGP に対応する。PDF記事（非公開）は認証が必要な

--- a/frontend/app/routes/feed.xml.ts
+++ b/frontend/app/routes/feed.xml.ts
@@ -1,47 +1,28 @@
 import { listBlogsApiV1BlogGet } from '~/api/sdk.gen'
-import type { BlogPostResponseSchema } from '~/api/types.gen'
 import { SITE_ORIGIN } from '~/lib/site'
 import { escapeXml } from '~/lib/xml'
 
 const FEED_TITLE = 'jaXiv'
 const FEED_DESCRIPTION = 'arXiv論文をやさしく解説するブログの新着記事'
 
-// feed取得時の1ページあたり件数。総数が多くてもページングで全件巡回する。
-const PAGE_SIZE = 100
-
-// フィードに載せる最大件数。RSSは新着中心で良いため上限を設ける。
-const MAX_ITEMS = 50
+// フィードに載せる件数。一覧APIは公開arXiv記事をcreated_at降順で返すため、先頭ページを
+// この件数だけ取得すれば新着順のフィードになる（page_sizeの上限は100）。
+const FEED_SIZE = 50
 
 // feed.xml リソースルート。default コンポーネントを持たず loader だけで RSS 2.0 を
-// 返す。公開されているarXiv記事（/blog/:paperId）を新着順で配信する。PDF記事は
-// 認証必須（/blog/pdf/:paperId）のため除外する。
+// 返す。一覧APIが公開arXiv記事をcreated_at降順で返す（PDF記事は認証必須で含まれない）
+// ため、先頭1ページのみ取得してそのまま配信する。
 export async function loader() {
-  const baseUrl = import.meta.env.VITE_API_BASE_URL
-  const posts: BlogPostResponseSchema[] = []
+  const { data, error } = await listBlogsApiV1BlogGet({
+    baseUrl: import.meta.env.VITE_API_BASE_URL,
+    query: { page: 1, page_size: FEED_SIZE },
+    throwOnError: false,
+  })
+  // 取得失敗時は部分的なfeedを200で返さず、5xxでリーダーに再試行させる。
+  if (error || !data)
+    throw new Response('Failed to build feed', { status: 503 })
 
-  // 1ページ目で total_pages を確認しつつ全ページを巡回する。
-  let page = 1
-  let totalPages = 1
-  do {
-    const { data, error } = await listBlogsApiV1BlogGet({
-      baseUrl,
-      query: { page, page_size: PAGE_SIZE },
-      throwOnError: false,
-    })
-    // 取得失敗時は部分的なfeedを200で返さず、5xxでリーダーに再試行させる。
-    if (error || !data)
-      throw new Response('Failed to build feed', { status: 503 })
-    for (const item of data.items) posts.push(item)
-    totalPages = data.total_pages
-    page += 1
-  } while (page <= totalPages)
-
-  // arXiv記事のみを新着順（created_at降順）で最大MAX_ITEMS件配信する。
-  // 一覧APIの並び順に依存しないよう、ここで明示的にソートする。
-  const items = posts
-    .filter(post => post.source_type === 'arxiv')
-    .sort((a, b) => b.created_at.localeCompare(a.created_at))
-    .slice(0, MAX_ITEMS)
+  const items = data.items
 
   const itemsXml = items
     .map(post => {

--- a/frontend/app/routes/feed.xml.ts
+++ b/frontend/app/routes/feed.xml.ts
@@ -1,0 +1,91 @@
+import { listBlogsApiV1BlogGet } from '~/api/sdk.gen'
+import type { BlogPostResponseSchema } from '~/api/types.gen'
+import { SITE_ORIGIN } from '~/lib/site'
+import { escapeXml } from '~/lib/xml'
+
+const FEED_TITLE = 'jaXiv'
+const FEED_DESCRIPTION = 'arXiv論文をやさしく解説するブログの新着記事'
+
+// feed取得時の1ページあたり件数。総数が多くてもページングで全件巡回する。
+const PAGE_SIZE = 100
+
+// フィードに載せる最大件数。RSSは新着中心で良いため上限を設ける。
+const MAX_ITEMS = 50
+
+// feed.xml リソースルート。default コンポーネントを持たず loader だけで RSS 2.0 を
+// 返す。公開されているarXiv記事（/blog/:paperId）を新着順で配信する。PDF記事は
+// 認証必須（/blog/pdf/:paperId）のため除外する。
+export async function loader() {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const posts: BlogPostResponseSchema[] = []
+
+  // 1ページ目で total_pages を確認しつつ全ページを巡回する。
+  let page = 1
+  let totalPages = 1
+  do {
+    const { data, error } = await listBlogsApiV1BlogGet({
+      baseUrl,
+      query: { page, page_size: PAGE_SIZE },
+      throwOnError: false,
+    })
+    // 取得失敗時は部分的なfeedを200で返さず、5xxでリーダーに再試行させる。
+    if (error || !data)
+      throw new Response('Failed to build feed', { status: 503 })
+    for (const item of data.items) posts.push(item)
+    totalPages = data.total_pages
+    page += 1
+  } while (page <= totalPages)
+
+  // arXiv記事のみを新着順（created_at降順）で最大MAX_ITEMS件配信する。
+  // 一覧APIの並び順に依存しないよう、ここで明示的にソートする。
+  const items = posts
+    .filter(post => post.source_type === 'arxiv')
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .slice(0, MAX_ITEMS)
+
+  const itemsXml = items
+    .map(post => {
+      const link = `${SITE_ORIGIN}/blog/${escapeXml(post.paper_id)}`
+      const creator = post.authors.length
+        ? `      <dc:creator>${escapeXml(post.authors.join(', '))}</dc:creator>\n`
+        : ``
+      return (
+        `    <item>\n` +
+        `      <title>${escapeXml(post.title)}</title>\n` +
+        `      <link>${link}</link>\n` +
+        `      <guid isPermaLink="true">${link}</guid>\n` +
+        `      <description>${escapeXml(post.summary)}</description>\n` +
+        creator +
+        `      <pubDate>${new Date(post.created_at).toUTCString()}</pubDate>\n` +
+        `    </item>`
+      )
+    })
+    .join('\n')
+
+  // channelのlastBuildDateには最新記事の公開日時を使う（記事ゼロ時は省略）。
+  const lastBuildDate = items[0]
+    ? `    <lastBuildDate>${new Date(items[0].created_at).toUTCString()}</lastBuildDate>\n`
+    : ``
+
+  const body =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">\n` +
+    `  <channel>\n` +
+    `    <title>${FEED_TITLE}</title>\n` +
+    `    <link>${SITE_ORIGIN}/blog</link>\n` +
+    `    <description>${FEED_DESCRIPTION}</description>\n` +
+    `    <language>ja</language>\n` +
+    `    <atom:link href="${SITE_ORIGIN}/feed.xml" rel="self" type="application/rss+xml" />\n` +
+    lastBuildDate +
+    (itemsXml ? `${itemsXml}\n` : ``) +
+    `  </channel>\n` +
+    `</rss>\n`
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      // Cloudflareでのキャッシュ（1時間）。運用に応じて調整可。
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}

--- a/frontend/app/routes/sitemap.xml.ts
+++ b/frontend/app/routes/sitemap.xml.ts
@@ -1,22 +1,12 @@
 import { listBlogsApiV1BlogGet } from '~/api/sdk.gen'
-
-const SITE_ORIGIN = 'https://jaxiv.utstudent-scienceblog.com'
+import { SITE_ORIGIN } from '~/lib/site'
+import { escapeXml } from '~/lib/xml'
 
 // 静的に載せたい主要ページ（公開ページのみ）
 const STATIC_PATHS = ['/', '/blog', '/pricing']
 
 // sitemap取得時の1ページあたり件数。総数が多くてもページングで全件巡回する。
 const PAGE_SIZE = 100
-
-// XMLの特殊文字をエスケープする。paper_idに特殊文字が入る想定は低いが安全のため。
-function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-}
 
 // sitemap.xml リソースルート。default コンポーネントを持たず loader だけで
 // XMLを返す。公開されている全arXiv記事（/blog/:paperId）と主要静的ページを列挙し、


### PR DESCRIPTION
## Summary
- ブログ購読ニーズに応えるため、arXiv公開記事を配信するRSSフィード(feed.xml)を追加。RSSリーダーやはてなブックマーク等からの購読・再訪導線を確保する。
- 既存の`sitemap.xml.ts`と同じリソースルート方式(loaderでResponseを返す)を踏襲し、実装・運用パターンを統一。
- 3箇所に重複していた`SITE_ORIGIN`とsitemap/feedで使う`escapeXml`を`lib`配下へ共通化し、重複を解消。

## Changes
- `frontend/app/routes/feed.xml.ts`(新規): RSS 2.0を返すリソースルート。arXiv記事のみを`created_at`降順で最大50件配信。各itemはtitle/link/guid/description(=summary)/dc:creator/pubDate(RFC822)、channelはtitle/link/description/language/atom:self/lastBuildDate。取得失敗時は503で再試行させる。`Content-Type: application/rss+xml`、`Cache-Control: max-age=3600`。
- `frontend/app/lib/site.ts`(新規): `SITE_ORIGIN`を共通化。
- `frontend/app/lib/xml.ts`(新規): `escapeXml`を共通化。
- `frontend/app/routes.ts`: `feed.xml`ルートを登録。
- `frontend/app/routes/sitemap.xml.ts` / `blog.$paperId.tsx`: 重複定義していた`SITE_ORIGIN`/`escapeXml`を共通モジュール参照へ置換。
- `frontend/app/root.tsx`: RSS autodiscovery用の`<link rel="alternate" type="application/rss+xml">`を追加。

## Test plan
- [ ] `cd frontend && npm run typecheck` が通ること
- [ ] `cd frontend && npm run lint` が通ること
- [ ] バックエンド起動後 `npm run dev` し、`curl http://localhost:3000/feed.xml` が RSS 2.0(application/rss+xml)を返し、arXiv記事のみが新着順で並ぶこと
- [ ] トップページのHTMLに `<link rel="alternate" type="application/rss+xml" href="/feed.xml">` が含まれRSSリーダーで自動検出できること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)