### PR TITLE
fix: DB接続プールにpool_pre_ping/pool_recycleを設定してconnection is closedエラーを解消

### DIFF
--- a/backend/infrastructure/postgres/database.py
+++ b/backend/infrastructure/postgres/database.py
@@ -20,7 +20,12 @@ def create_async_session_factory() -> async_sessionmaker[AsyncSession]:
 	elif postgres_url.startswith('postgres://'):
 		postgres_url = postgres_url.replace('postgres://', 'postgresql+asyncpg://', 1)
 
-	engine = create_async_engine(postgres_url, echo=False)
+	engine = create_async_engine(
+		postgres_url,
+		echo=False,
+		pool_pre_ping=True,
+		pool_recycle=1800,
+	)
 	return async_sessionmaker(engine, expire_on_commit=False)
 
 


### PR DESCRIPTION
## Summary
- Renderのログで発生していた `asyncpg.exceptions._base.InterfaceError: connection is closed` を修正
- 原因: Supabase(Supavisor)側のアイドルタイムアウトでサーバー側から切断されたコネクションを、SQLAlchemyのプールがそのまま使い回してしまい、次のクエリ実行時にasyncpgが「接続が閉じている」というエラーを投げていた
- `create_async_engine` に `pool_pre_ping=True` を設定し、コネクションを貸し出す前にヘルスチェックを行い、死んでいる場合は透過的に再接続するようにした
- あわせて `pool_recycle=1800` を設定し、Supabase側のアイドルタイムアウトより短い周期でコネクションを定期的にリサイクルするようにした

## Test plan
- [x] `uv run ruff check infrastructure/postgres/database.py`
- [x] `uv run mypy infrastructure/postgres/database.py`
- [ ] Renderへのデプロイ後、しばらく間隔を空けたリクエストで `connection is closed` エラーが再発しないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01VuSjpvjv9hfxDPoShZDSow)_