### PR TITLE
feat(frontend): X共有カードをsummary形式(左サムネ+右テキスト)に統一

### DIFF
--- a/frontend/app/routes/blog.$paperId.tsx
+++ b/frontend/app/routes/blog.$paperId.tsx
@@ -31,7 +31,8 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
   const url = `${SITE_ORIGIN}${location.pathname}`
   const title = `${loaderData.title} | jaXiv`
   const description = loaderData.summary
-  const imageUrl = loaderData.ogImageUrl
+  // 図がない記事はブランドロゴをサムネイルにして、画像なしカードを避ける
+  const imageUrl = loaderData.ogImageUrl ?? `${SITE_ORIGIN}/icon-512.png`
 
   return [
     { title },
@@ -42,15 +43,13 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
     { property: 'og:description', content: description },
     { property: 'og:url', content: url },
     { property: 'og:site_name', content: 'jaXiv' },
-    ...(imageUrl ? [{ property: 'og:image', content: imageUrl }] : []),
-    // Twitter Card
-    {
-      name: 'twitter:card',
-      content: imageUrl ? 'summary_large_image' : 'summary',
-    },
+    { property: 'og:image', content: imageUrl },
+    // Twitter Card: 左サムネイル+右テキストの summary 形式に固定する。
+    // summary_large_image はX上でタイトル・説明文が表示されないため使わない。
+    { name: 'twitter:card', content: 'summary' },
     { name: 'twitter:title', content: title },
     { name: 'twitter:description', content: description },
-    ...(imageUrl ? [{ name: 'twitter:image', content: imageUrl }] : []),
+    { name: 'twitter:image', content: imageUrl },
     // 正規URL
     { tagName: 'link', rel: 'canonical', href: url },
     // 構造化データ（学術記事）
@@ -60,7 +59,8 @@ export function meta({ loaderData, location }: Route.MetaArgs) {
         '@type': 'ScholarlyArticle',
         headline: loaderData.title,
         abstract: description,
-        image: imageUrl ?? undefined,
+        // 構造化データには記事本来の図版のみを載せる（ロゴは記事画像ではない）
+        image: loaderData.ogImageUrl,
         inLanguage: 'ja',
         author:
           loaderData.authors.length > 0


### PR DESCRIPTION
## 概要

X（Twitter）でブログ記事を共有したときのカード表示を、左に正方形サムネイル・右にタイトル＋説明文が並ぶ `summary` 形式に統一します。

## 背景

現状のOGP設計には2つの問題がありました。

- 本文に図がある記事は `summary_large_image` になるが、Xは2023年以降このカード形式でタイトル・説明文を表示しないため、図だけがドメイン名付きで表示され記事タイトルが読めない
- 図がない記事は `og:image` なしの `summary` カードになり、サムネイル枠がプレースホルダーアイコンのままになる

## 変更内容

- `twitter:card` を常に `summary` に固定（`summary_large_image` を廃止）
- `og:image` / `twitter:image` を常に設定し、本文に図がない記事は既存のブランドロゴ `icon-512.png`（正方形512px）をフォールバックとして使用
- 構造化データ（ScholarlyArticle）の `image` は記事本来の図版のみを載せるよう維持（ロゴは記事画像ではないため）

これにより全記事でサムネイル＋タイトル＋説明文が読めるカードになります。

## 確認

- `npm run typecheck` / `eslint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmiGwJGd39P9FGKpgAowAK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmiGwJGd39P9FGKpgAowAK)_