### PR TITLE
feat(backend): トピック購読API（週次論文ダイジェスト登録/取得）を追加

### DIFF
--- a/backend/alembic/versions/46e9bcb3e8ef_add_user_topic_subscription.py
+++ b/backend/alembic/versions/46e9bcb3e8ef_add_user_topic_subscription.py
@@ -1,0 +1,81 @@
+"""add user topic subscription
+
+Revision ID: 46e9bcb3e8ef
+Revises: d9e2f1a3b4c5
+Create Date: 2026-07-12 00:16:28.339587
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '46e9bcb3e8ef'
+down_revision: Union[str, Sequence[str], None] = 'd9e2f1a3b4c5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = 'user_topic_subscription'
+
+
+def upgrade() -> None:
+	"""Upgrade schema."""
+	op.create_table(
+		TABLE,
+		sa.Column('id', sa.Uuid(), nullable=False),
+		sa.Column('user_id', sa.UUID(), nullable=False),
+		sa.Column('email', sa.Text(), nullable=False),
+		sa.Column('keywords', sa.ARRAY(sa.String()), server_default='{}', nullable=False),
+		sa.Column('is_active', sa.Boolean(), server_default='true', nullable=False),
+		sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+		sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+		sa.PrimaryKeyConstraint('id'),
+	)
+	op.create_index(op.f('ix_user_topic_subscription_user_id'), TABLE, ['user_id'], unique=True)
+
+	# RLS: the backend uses the service role and bypasses these policies; they
+	# guard direct client (Supabase JS) access so users only see their own row.
+	op.enable_rls(TABLE)
+	op.create_rls_policy(
+		'topic_subscription_select',
+		TABLE,
+		command='SELECT',
+		to='authenticated',
+		using='auth.uid() = user_id',
+	)
+	op.create_rls_policy(
+		'topic_subscription_insert',
+		TABLE,
+		command='INSERT',
+		to='authenticated',
+		with_check='auth.uid() = user_id',
+	)
+	op.create_rls_policy(
+		'topic_subscription_update',
+		TABLE,
+		command='UPDATE',
+		to='authenticated',
+		using='auth.uid() = user_id',
+		with_check='auth.uid() = user_id',
+	)
+	op.create_rls_policy(
+		'topic_subscription_delete',
+		TABLE,
+		command='DELETE',
+		to='authenticated',
+		using='auth.uid() = user_id',
+	)
+
+
+def downgrade() -> None:
+	"""Downgrade schema."""
+	op.drop_rls_policy('topic_subscription_delete', TABLE)
+	op.drop_rls_policy('topic_subscription_update', TABLE)
+	op.drop_rls_policy('topic_subscription_insert', TABLE)
+	op.drop_rls_policy('topic_subscription_select', TABLE)
+	op.disable_rls(TABLE)
+	op.drop_index(op.f('ix_user_topic_subscription_user_id'), table_name=TABLE)
+	op.drop_table(TABLE)

--- a/backend/alembic/versions/46e9bcb3e8ef_add_user_topic_subscription.py
+++ b/backend/alembic/versions/46e9bcb3e8ef_add_user_topic_subscription.py
@@ -27,7 +27,6 @@ def upgrade() -> None:
 		TABLE,
 		sa.Column('id', sa.Uuid(), nullable=False),
 		sa.Column('user_id', sa.UUID(), nullable=False),
-		sa.Column('email', sa.Text(), nullable=False),
 		sa.Column('keywords', sa.ARRAY(sa.String()), server_default='{}', nullable=False),
 		sa.Column('is_active', sa.Boolean(), server_default='true', nullable=False),
 		sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),

--- a/backend/application/usecase/__init__.py
+++ b/backend/application/usecase/__init__.py
@@ -10,6 +10,7 @@ from .get_chat_thread import GetChatThreadUseCase
 from .get_my_chat_daily_count import ChatDailyCount, GetMyChatDailyCountUseCase
 from .get_my_generation_count import GetMyGenerationCountUseCase
 from .get_my_subscription import GetMySubscriptionUseCase, MySubscriptionView
+from .get_my_topic_subscription import GetMyTopicSubscriptionUseCase
 from .handle_stripe_webhook import HandleStripeWebhookUseCase
 from .list_blog_posts import ListBlogPostsUseCase
 from .list_chat_threads import ChatThreadSummary, ListChatThreadsUseCase
@@ -25,6 +26,7 @@ from .suggest_figures import (
 	SuggestFiguresUseCase,
 )
 from .translate_arxiv_paper import TranslateArxivPaper
+from .upsert_topic_subscription import UpsertTopicSubscriptionUseCase
 
 __all__ = [
 	'ArxivRedirector',
@@ -42,6 +44,7 @@ __all__ = [
 	'GetMyChatDailyCountUseCase',
 	'GetMyGenerationCountUseCase',
 	'GetMySubscriptionUseCase',
+	'GetMyTopicSubscriptionUseCase',
 	'HandleStripeWebhookUseCase',
 	'ListBlogPostsUseCase',
 	'ListChatThreadsUseCase',
@@ -55,4 +58,5 @@ __all__ = [
 	'SuggestFiguresResult',
 	'SuggestFiguresUseCase',
 	'TranslateArxivPaper',
+	'UpsertTopicSubscriptionUseCase',
 ]

--- a/backend/application/usecase/get_my_topic_subscription.py
+++ b/backend/application/usecase/get_my_topic_subscription.py
@@ -1,0 +1,13 @@
+from domain.entities.topic_subscription import TopicSubscription
+from domain.repositories import ITopicSubscriptionRepository
+from domain.value_objects.user_id import UserId
+
+
+class GetMyTopicSubscriptionUseCase:
+	"""Return the caller's topic subscription, or ``None`` if not subscribed yet."""
+
+	def __init__(self, repo: ITopicSubscriptionRepository) -> None:
+		self._repo = repo
+
+	async def execute(self, user_id: UserId) -> TopicSubscription | None:
+		return await self._repo.find_by_user_id(user_id)

--- a/backend/application/usecase/upsert_topic_subscription.py
+++ b/backend/application/usecase/upsert_topic_subscription.py
@@ -13,6 +13,6 @@ class UpsertTopicSubscriptionUseCase:
 	def __init__(self, repo: ITopicSubscriptionRepository) -> None:
 		self._repo = repo
 
-	async def execute(self, user_id: UserId, email: str, keywords: list[str]) -> TopicSubscription:
-		subscription = TopicSubscription(user_id=user_id, email=email, keywords=keywords)
+	async def execute(self, user_id: UserId, keywords: list[str]) -> TopicSubscription:
+		subscription = TopicSubscription(user_id=user_id, keywords=keywords)
 		return await self._repo.upsert(subscription)

--- a/backend/application/usecase/upsert_topic_subscription.py
+++ b/backend/application/usecase/upsert_topic_subscription.py
@@ -1,0 +1,18 @@
+from domain.entities.topic_subscription import TopicSubscription
+from domain.repositories import ITopicSubscriptionRepository
+from domain.value_objects.user_id import UserId
+
+
+class UpsertTopicSubscriptionUseCase:
+	"""Create or update the caller's topic subscription.
+
+	Saving keywords implies opting into the digest, so the subscription is
+	(re)activated. The repository upsert preserves the existing id/created_at.
+	"""
+
+	def __init__(self, repo: ITopicSubscriptionRepository) -> None:
+		self._repo = repo
+
+	async def execute(self, user_id: UserId, email: str, keywords: list[str]) -> TopicSubscription:
+		subscription = TopicSubscription(user_id=user_id, email=email, keywords=keywords)
+		return await self._repo.upsert(subscription)

--- a/backend/controller/__init__.py
+++ b/backend/controller/__init__.py
@@ -4,6 +4,7 @@ from .billing import router as billing_router
 from .blog import router as blog_router
 from .chat import router as chat_router
 from .figure_suggestion import router as figure_suggestion_router
+from .subscription import router as subscription_router
 from .translate import router as translate_router
 
 router = APIRouter()
@@ -12,5 +13,6 @@ router.include_router(blog_router)
 router.include_router(chat_router)
 router.include_router(billing_router)
 router.include_router(figure_suggestion_router)
+router.include_router(subscription_router)
 
 __all__ = ['router']

--- a/backend/controller/schemas/subscription.py
+++ b/backend/controller/schemas/subscription.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from domain.entities.topic_subscription import TopicSubscription
+
+
+class UpsertTopicSubscriptionRequest(BaseModel):
+	keywords: list[str] = Field(
+		default_factory=list,
+		description='Keywords to match papers against (normalized server-side)',
+	)
+
+
+class TopicSubscriptionResponse(BaseModel):
+	keywords: list[str]
+	is_active: bool
+
+	@classmethod
+	def from_entity(cls, subscription: TopicSubscription) -> TopicSubscriptionResponse:
+		return cls(keywords=subscription.keywords, is_active=subscription.is_active)

--- a/backend/controller/subscription.py
+++ b/backend/controller/subscription.py
@@ -1,0 +1,47 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from application.usecase import (
+	GetMyTopicSubscriptionUseCase,
+	UpsertTopicSubscriptionUseCase,
+)
+from controller.schemas.subscription import (
+	TopicSubscriptionResponse,
+	UpsertTopicSubscriptionRequest,
+)
+from infrastructure.dependencies import (
+	SubscriberIdentity,
+	get_get_my_topic_subscription_use_case,
+	get_subscriber_identity,
+	get_upsert_topic_subscription_use_case,
+)
+
+router = APIRouter(prefix='/api/v1/subscriptions')
+
+
+@router.get('/me', response_model=TopicSubscriptionResponse)
+async def get_my_topic_subscription(
+	identity: Annotated[SubscriberIdentity, Depends(get_subscriber_identity)],
+	use_case: Annotated[
+		GetMyTopicSubscriptionUseCase, Depends(get_get_my_topic_subscription_use_case)
+	],
+) -> TopicSubscriptionResponse:
+	subscription = await use_case.execute(user_id=identity.user_id)
+	if subscription is None:
+		return TopicSubscriptionResponse(keywords=[], is_active=False)
+	return TopicSubscriptionResponse.from_entity(subscription)
+
+
+@router.put('/me', response_model=TopicSubscriptionResponse)
+async def upsert_my_topic_subscription(
+	body: UpsertTopicSubscriptionRequest,
+	identity: Annotated[SubscriberIdentity, Depends(get_subscriber_identity)],
+	use_case: Annotated[
+		UpsertTopicSubscriptionUseCase, Depends(get_upsert_topic_subscription_use_case)
+	],
+) -> TopicSubscriptionResponse:
+	subscription = await use_case.execute(
+		user_id=identity.user_id, email=identity.email, keywords=body.keywords
+	)
+	return TopicSubscriptionResponse.from_entity(subscription)

--- a/backend/controller/subscription.py
+++ b/backend/controller/subscription.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
@@ -10,10 +11,10 @@ from controller.schemas.subscription import (
 	TopicSubscriptionResponse,
 	UpsertTopicSubscriptionRequest,
 )
+from domain.value_objects.user_id import UserId
 from infrastructure.dependencies import (
-	SubscriberIdentity,
 	get_get_my_topic_subscription_use_case,
-	get_subscriber_identity,
+	get_required_user_id,
 	get_upsert_topic_subscription_use_case,
 )
 
@@ -22,12 +23,12 @@ router = APIRouter(prefix='/api/v1/subscriptions')
 
 @router.get('/me', response_model=TopicSubscriptionResponse)
 async def get_my_topic_subscription(
-	identity: Annotated[SubscriberIdentity, Depends(get_subscriber_identity)],
+	user_id: Annotated[uuid.UUID, Depends(get_required_user_id)],
 	use_case: Annotated[
 		GetMyTopicSubscriptionUseCase, Depends(get_get_my_topic_subscription_use_case)
 	],
 ) -> TopicSubscriptionResponse:
-	subscription = await use_case.execute(user_id=identity.user_id)
+	subscription = await use_case.execute(user_id=UserId(user_id))
 	if subscription is None:
 		return TopicSubscriptionResponse(keywords=[], is_active=False)
 	return TopicSubscriptionResponse.from_entity(subscription)
@@ -36,12 +37,10 @@ async def get_my_topic_subscription(
 @router.put('/me', response_model=TopicSubscriptionResponse)
 async def upsert_my_topic_subscription(
 	body: UpsertTopicSubscriptionRequest,
-	identity: Annotated[SubscriberIdentity, Depends(get_subscriber_identity)],
+	user_id: Annotated[uuid.UUID, Depends(get_required_user_id)],
 	use_case: Annotated[
 		UpsertTopicSubscriptionUseCase, Depends(get_upsert_topic_subscription_use_case)
 	],
 ) -> TopicSubscriptionResponse:
-	subscription = await use_case.execute(
-		user_id=identity.user_id, email=identity.email, keywords=body.keywords
-	)
+	subscription = await use_case.execute(user_id=UserId(user_id), keywords=body.keywords)
 	return TopicSubscriptionResponse.from_entity(subscription)

--- a/backend/domain/entities/topic_subscription.py
+++ b/backend/domain/entities/topic_subscription.py
@@ -21,7 +21,6 @@ class TopicSubscription(BaseModel):
 
 	id: uuid.UUID = Field(default_factory=uuid.uuid4)
 	user_id: UserId
-	email: str = Field(description='Email address to deliver the digest to')
 	keywords: list[str] = Field(
 		default_factory=list, description='Keywords to match papers against'
 	)

--- a/backend/domain/entities/topic_subscription.py
+++ b/backend/domain/entities/topic_subscription.py
@@ -1,0 +1,44 @@
+import uuid
+from datetime import UTC, datetime
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from domain.value_objects.user_id import UserId
+
+
+class TopicSubscription(BaseModel):
+	"""A user's topic subscription for the weekly paper-digest email.
+
+	Keyed by ``user_id`` (one subscription per user). ``email`` is captured from
+	the user's authenticated token at save time so the background digest job can
+	send without a live JWT. ``keywords`` are normalized (see below).
+	"""
+
+	MAX_KEYWORDS: ClassVar[int] = 20
+
+	model_config = ConfigDict(frozen=False)
+
+	id: uuid.UUID = Field(default_factory=uuid.uuid4)
+	user_id: UserId
+	email: str = Field(description='Email address to deliver the digest to')
+	keywords: list[str] = Field(
+		default_factory=list, description='Keywords to match papers against'
+	)
+	is_active: bool = Field(default=True, description='Whether the weekly digest is enabled')
+	created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+	updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+	@field_validator('keywords')
+	@classmethod
+	def _normalize_keywords(cls, raw: list[str]) -> list[str]:
+		"""Strip, lowercase, drop blanks, dedupe (order-preserving), cap to MAX_KEYWORDS."""
+		normalized: list[str] = []
+		seen: set[str] = set()
+		for keyword in raw:
+			cleaned = keyword.strip().lower()
+			if not cleaned or cleaned in seen:
+				continue
+			seen.add(cleaned)
+			normalized.append(cleaned)
+		return normalized[: cls.MAX_KEYWORDS]

--- a/backend/domain/repositories/__init__.py
+++ b/backend/domain/repositories/__init__.py
@@ -4,6 +4,7 @@ from .i_figure_chunk_repository import GlobalFigureHit, IFigureChunkRepository
 from .i_figure_storage_repository import IFigureStorageRepository
 from .i_file_storage_repository import IFileStorageRepository
 from .i_text_chunk_repository import ITextChunkRepository
+from .i_topic_subscription_repository import ITopicSubscriptionRepository
 from .i_translated_arxiv_repository import ITranslatedArxivRepository
 from .i_usage_repository import IUsageRepository
 from .i_user_subscription_repository import IUserSubscriptionRepository
@@ -16,6 +17,7 @@ __all__ = [
 	'IFigureStorageRepository',
 	'IFileStorageRepository',
 	'ITextChunkRepository',
+	'ITopicSubscriptionRepository',
 	'ITranslatedArxivRepository',
 	'IUsageRepository',
 	'IUserSubscriptionRepository',

--- a/backend/domain/repositories/i_topic_subscription_repository.py
+++ b/backend/domain/repositories/i_topic_subscription_repository.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from domain.entities.topic_subscription import TopicSubscription
+from domain.value_objects.user_id import UserId
+
+
+class ITopicSubscriptionRepository(ABC):
+	"""Repository for users' weekly-digest topic subscriptions."""
+
+	@abstractmethod
+	async def find_by_user_id(self, user_id: UserId) -> TopicSubscription | None:
+		"""Find a user's topic subscription by their user ID."""
+		raise NotImplementedError
+
+	@abstractmethod
+	async def upsert(self, subscription: TopicSubscription) -> TopicSubscription:
+		"""Create or update a user's topic subscription and return the persisted entity."""
+		raise NotImplementedError

--- a/backend/infrastructure/dependencies.py
+++ b/backend/infrastructure/dependencies.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from application.unit_of_works import (
@@ -23,6 +24,7 @@ from application.usecase import (
 	GetMyChatDailyCountUseCase,
 	GetMyGenerationCountUseCase,
 	GetMySubscriptionUseCase,
+	GetMyTopicSubscriptionUseCase,
 	HandleStripeWebhookUseCase,
 	ListBlogPostsUseCase,
 	ListChatThreadsUseCase,
@@ -34,6 +36,7 @@ from application.usecase import (
 	StartCustomerPortalUseCase,
 	SuggestFiguresUseCase,
 	TranslateArxivPaper,
+	UpsertTopicSubscriptionUseCase,
 )
 from domain.entities.auth_user import AuthUser
 from domain.gateways import (
@@ -57,6 +60,7 @@ from domain.repositories import (
 	IFigureStorageRepository,
 	IFileStorageRepository,
 	ITextChunkRepository,
+	ITopicSubscriptionRepository,
 	ITranslatedArxivRepository,
 	IUsageRepository,
 	IUserSubscriptionRepository,
@@ -90,6 +94,7 @@ from infrastructure.postgres import (
 from infrastructure.postgres.repositories import (
 	PostgresBlogPostRepository,
 	PostgresChatThreadRepository,
+	PostgresTopicSubscriptionRepository,
 	PostgresTranslatedArxivRepository,
 	PostgresUserSubscriptionRepository,
 )
@@ -211,6 +216,40 @@ async def get_required_user_id(
 			detail='Full authentication is required. Please sign in with Google.',
 		)
 	return get_user_id_from_payload(payload)
+
+
+class SubscriberIdentity(BaseModel):
+	"""Authenticated identity for digest-subscription endpoints (user_id + email)."""
+
+	model_config = ConfigDict(frozen=True)
+
+	user_id: UserId
+	email: str
+
+
+async def get_subscriber_identity(
+	credentials: Annotated[
+		HTTPAuthorizationCredentials | None, Security(HTTPBearer(auto_error=False))
+	],
+) -> SubscriberIdentity:
+	"""Build a SubscriberIdentity from Bearer JWT; 401 if missing, 403 if anonymous.
+
+	Captures the ``email`` claim so the background digest job can send without a
+	live token.
+	"""
+	if credentials is None:
+		raise HTTPException(status_code=401, detail='Authentication required.')
+	payload = verify_supabase_jwt(credentials.credentials)
+	if payload.get('is_anonymous', False):
+		raise HTTPException(
+			status_code=403,
+			detail='Full authentication is required. Please sign in with Google.',
+		)
+	user_id = get_user_id_from_payload(payload)
+	email = payload.get('email')
+	if not email:
+		raise HTTPException(status_code=400, detail='Email is not available on the token.')
+	return SubscriberIdentity(user_id=UserId(user_id), email=email)
 
 
 # --------------------------------------
@@ -601,3 +640,24 @@ def get_handle_stripe_webhook_use_case(
 	repo: Annotated[IUserSubscriptionRepository, Depends(get_user_subscription_repository)],
 ) -> HandleStripeWebhookUseCase:
 	return HandleStripeWebhookUseCase(billing=billing, repo=repo)
+
+
+# --------------------------------------
+# Topic subscription providers
+# --------------------------------------
+async def get_topic_subscription_repository(
+	session: Annotated[AsyncSession, Depends(get_async_session)],
+) -> ITopicSubscriptionRepository:
+	return PostgresTopicSubscriptionRepository(session=session)
+
+
+def get_get_my_topic_subscription_use_case(
+	repo: Annotated[ITopicSubscriptionRepository, Depends(get_topic_subscription_repository)],
+) -> GetMyTopicSubscriptionUseCase:
+	return GetMyTopicSubscriptionUseCase(repo=repo)
+
+
+def get_upsert_topic_subscription_use_case(
+	repo: Annotated[ITopicSubscriptionRepository, Depends(get_topic_subscription_repository)],
+) -> UpsertTopicSubscriptionUseCase:
+	return UpsertTopicSubscriptionUseCase(repo=repo)

--- a/backend/infrastructure/dependencies.py
+++ b/backend/infrastructure/dependencies.py
@@ -4,7 +4,6 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from application.unit_of_works import (
@@ -216,40 +215,6 @@ async def get_required_user_id(
 			detail='Full authentication is required. Please sign in with Google.',
 		)
 	return get_user_id_from_payload(payload)
-
-
-class SubscriberIdentity(BaseModel):
-	"""Authenticated identity for digest-subscription endpoints (user_id + email)."""
-
-	model_config = ConfigDict(frozen=True)
-
-	user_id: UserId
-	email: str
-
-
-async def get_subscriber_identity(
-	credentials: Annotated[
-		HTTPAuthorizationCredentials | None, Security(HTTPBearer(auto_error=False))
-	],
-) -> SubscriberIdentity:
-	"""Build a SubscriberIdentity from Bearer JWT; 401 if missing, 403 if anonymous.
-
-	Captures the ``email`` claim so the background digest job can send without a
-	live token.
-	"""
-	if credentials is None:
-		raise HTTPException(status_code=401, detail='Authentication required.')
-	payload = verify_supabase_jwt(credentials.credentials)
-	if payload.get('is_anonymous', False):
-		raise HTTPException(
-			status_code=403,
-			detail='Full authentication is required. Please sign in with Google.',
-		)
-	user_id = get_user_id_from_payload(payload)
-	email = payload.get('email')
-	if not email:
-		raise HTTPException(status_code=400, detail='Email is not available on the token.')
-	return SubscriberIdentity(user_id=UserId(user_id), email=email)
 
 
 # --------------------------------------

--- a/backend/infrastructure/postgres/models.py
+++ b/backend/infrastructure/postgres/models.py
@@ -127,10 +127,6 @@ class UserTopicSubscriptionModel(SQLModel, table=True):
 		sa_column=Column(PG_UUID(as_uuid=True), nullable=False, unique=True, index=True),
 		description='Supabase auth.users.id',
 	)
-	email: str = Field(
-		sa_column=Column(Text, nullable=False),
-		description='Email address to deliver the digest to',
-	)
 	keywords: list[str] = Field(
 		sa_column=Column(ARRAY(String), nullable=False, server_default='{}'),
 		description='Keywords to match papers against',

--- a/backend/infrastructure/postgres/models.py
+++ b/backend/infrastructure/postgres/models.py
@@ -117,3 +117,28 @@ class UserSubscriptionModel(SQLModel, table=True):
 	)
 	created_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
 	updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
+
+
+class UserTopicSubscriptionModel(SQLModel, table=True):
+	__tablename__ = 'user_topic_subscription'  # type: ignore[assignment]
+
+	id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+	user_id: uuid.UUID = Field(
+		sa_column=Column(PG_UUID(as_uuid=True), nullable=False, unique=True, index=True),
+		description='Supabase auth.users.id',
+	)
+	email: str = Field(
+		sa_column=Column(Text, nullable=False),
+		description='Email address to deliver the digest to',
+	)
+	keywords: list[str] = Field(
+		sa_column=Column(ARRAY(String), nullable=False, server_default='{}'),
+		description='Keywords to match papers against',
+	)
+	is_active: bool = Field(
+		sa_column=Column(Boolean, nullable=False, server_default='true'),
+		default=True,
+		description='Whether the weekly digest is enabled',
+	)
+	created_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
+	updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))

--- a/backend/infrastructure/postgres/repositories/__init__.py
+++ b/backend/infrastructure/postgres/repositories/__init__.py
@@ -1,11 +1,13 @@
 from .postgres_blog_post_repository import PostgresBlogPostRepository
 from .postgres_chat_thread_repository import PostgresChatThreadRepository
+from .postgres_topic_subscription_repository import PostgresTopicSubscriptionRepository
 from .postgres_translated_arxiv_repository import PostgresTranslatedArxivRepository
 from .postgres_user_subscription_repository import PostgresUserSubscriptionRepository
 
 __all__ = [
 	'PostgresBlogPostRepository',
 	'PostgresChatThreadRepository',
+	'PostgresTopicSubscriptionRepository',
 	'PostgresTranslatedArxivRepository',
 	'PostgresUserSubscriptionRepository',
 ]

--- a/backend/infrastructure/postgres/repositories/postgres_topic_subscription_repository.py
+++ b/backend/infrastructure/postgres/repositories/postgres_topic_subscription_repository.py
@@ -24,7 +24,6 @@ class PostgresTopicSubscriptionRepository(ITopicSubscriptionRepository):
 		return TopicSubscription(
 			id=row.id,
 			user_id=UserId(row.user_id),
-			email=row.email,
 			keywords=row.keywords or [],
 			is_active=row.is_active,
 			created_at=row.created_at,
@@ -36,7 +35,8 @@ class PostgresTopicSubscriptionRepository(ITopicSubscriptionRepository):
 			col(UserTopicSubscriptionModel.user_id) == user_id.root
 		)
 		result = await self._session.execute(stmt)
-		row = result.scalars().first()
+		# user_id is unique, so there is at most one row.
+		row = result.scalars().one_or_none()
 		return self._to_entity(row) if row is not None else None
 
 	async def upsert(self, subscription: TopicSubscription) -> TopicSubscription:
@@ -44,7 +44,6 @@ class PostgresTopicSubscriptionRepository(ITopicSubscriptionRepository):
 		values = {
 			'id': subscription.id,
 			'user_id': subscription.user_id.root,
-			'email': subscription.email,
 			'keywords': subscription.keywords,
 			'is_active': subscription.is_active,
 			'created_at': now,
@@ -55,14 +54,11 @@ class PostgresTopicSubscriptionRepository(ITopicSubscriptionRepository):
 		stmt = stmt.on_conflict_do_update(
 			index_elements=['user_id'],
 			set_={
-				'email': stmt.excluded.email,
 				'keywords': stmt.excluded.keywords,
 				'is_active': stmt.excluded.is_active,
 				'updated_at': stmt.excluded.updated_at,
 			},
 		)
-		await self._session.execute(stmt)
-
-		refreshed = await self.find_by_user_id(subscription.user_id)
-		assert refreshed is not None
-		return refreshed
+		result = await self._session.execute(stmt.returning(UserTopicSubscriptionModel))
+		row = result.scalars().one()
+		return self._to_entity(row)

--- a/backend/infrastructure/postgres/repositories/postgres_topic_subscription_repository.py
+++ b/backend/infrastructure/postgres/repositories/postgres_topic_subscription_repository.py
@@ -1,0 +1,68 @@
+from datetime import UTC, datetime
+from logging import getLogger
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from domain.entities.topic_subscription import TopicSubscription
+from domain.repositories import ITopicSubscriptionRepository
+from domain.value_objects.user_id import UserId
+
+from ..models import UserTopicSubscriptionModel
+
+
+class PostgresTopicSubscriptionRepository(ITopicSubscriptionRepository):
+	"""Maps ``TopicSubscription`` to the ``user_topic_subscription`` table."""
+
+	def __init__(self, session: AsyncSession):
+		self._session = session
+		self._logger = getLogger(__name__)
+
+	def _to_entity(self, row: UserTopicSubscriptionModel) -> TopicSubscription:
+		return TopicSubscription(
+			id=row.id,
+			user_id=UserId(row.user_id),
+			email=row.email,
+			keywords=row.keywords or [],
+			is_active=row.is_active,
+			created_at=row.created_at,
+			updated_at=row.updated_at,
+		)
+
+	async def find_by_user_id(self, user_id: UserId) -> TopicSubscription | None:
+		stmt = select(UserTopicSubscriptionModel).where(
+			col(UserTopicSubscriptionModel.user_id) == user_id.root
+		)
+		result = await self._session.execute(stmt)
+		row = result.scalars().first()
+		return self._to_entity(row) if row is not None else None
+
+	async def upsert(self, subscription: TopicSubscription) -> TopicSubscription:
+		now = datetime.now(UTC)
+		values = {
+			'id': subscription.id,
+			'user_id': subscription.user_id.root,
+			'email': subscription.email,
+			'keywords': subscription.keywords,
+			'is_active': subscription.is_active,
+			'created_at': now,
+			'updated_at': now,
+		}
+		stmt = pg_insert(UserTopicSubscriptionModel).values(**values)
+		# On conflict, preserve id/created_at and only refresh the mutable fields.
+		stmt = stmt.on_conflict_do_update(
+			index_elements=['user_id'],
+			set_={
+				'email': stmt.excluded.email,
+				'keywords': stmt.excluded.keywords,
+				'is_active': stmt.excluded.is_active,
+				'updated_at': stmt.excluded.updated_at,
+			},
+		)
+		await self._session.execute(stmt)
+
+		refreshed = await self.find_by_user_id(subscription.user_id)
+		assert refreshed is not None
+		return refreshed

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -931,6 +931,70 @@
         ]
       }
     },
+    "/api/v1/subscriptions/me": {
+      "get": {
+        "summary": "Get My Topic Subscription",
+        "operationId": "get_my_topic_subscription_api_v1_subscriptions_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopicSubscriptionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "put": {
+        "summary": "Upsert My Topic Subscription",
+        "operationId": "upsert_my_topic_subscription_api_v1_subscriptions_me_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertTopicSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopicSubscriptionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",
@@ -1708,6 +1772,27 @@
         ],
         "title": "ToolUseBlock"
       },
+      "TopicSubscriptionResponse": {
+        "properties": {
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "type": "object",
+        "required": [
+          "keywords",
+          "is_active"
+        ],
+        "title": "TopicSubscriptionResponse"
+      },
       "TranslateResponseSchema": {
         "properties": {
           "message": {
@@ -1733,6 +1818,20 @@
           "translated_language"
         ],
         "title": "TranslateResponseSchema"
+      },
+      "UpsertTopicSubscriptionRequest": {
+        "properties": {
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords",
+            "description": "Keywords to match papers against (normalized server-side)"
+          }
+        },
+        "type": "object",
+        "title": "UpsertTopicSubscriptionRequest"
       },
       "ValidationError": {
         "properties": {


### PR DESCRIPTION
## Summary
- 論文ダイジェストのパーソナライズ配信機能の第1弾（PR①）。ユーザーがキーワードを設定して購読するためのAPIを追加する
- コストを抑えるため「ユーザーごとに生成」ではなく既存の公開ブログプールから選定して配信する設計。本PRはその土台となる購読モデルとCRUD APIのみ
- バックグラウンドの配信ジョブがJWTなしで送信できるよう、購読登録時にJWTの`email`クレームを保存する

## Changes
- `domain/entities/topic_subscription.py`: `TopicSubscription` エンティティ（キーワードを strip/lower/重複排除/上限20件に正規化）
- `domain/repositories/i_topic_subscription_repository.py` + `infrastructure/postgres/repositories/postgres_topic_subscription_repository.py`: `find_by_user_id` / `upsert`（`user_id` 一意の `on_conflict_do_update`、既存 `UserSubscription` と同方式）
- `infrastructure/postgres/models.py`: `UserTopicSubscriptionModel`（`user_topic_subscription` テーブル、`user_id` UNIQUE）
- `application/usecase/{upsert,get_my}_topic_subscription.py`: 購読の作成/更新・取得ユースケース
- `controller/subscription.py` + `controller/schemas/subscription.py`: `GET`/`PUT /api/v1/subscriptions/me`
- `infrastructure/dependencies.py`: `SubscriberIdentity` と `get_subscriber_identity`（JWT から `user_id`+`email` を取得、匿名は403）＋各プロバイダ
- `openapi.json`: 再生成

## Test plan
- [ ] **マイグレーション未同梱**（本PRの必須フォローアップ）: 実DBに対し `cd backend && just gen-migration \"add user topic subscription\"` を実行し、生成物の `upgrade()/downgrade()` に `user_topic_subscription` の RLS（authenticated が `auth.uid() = user_id` で SELECT/INSERT/UPDATE/DELETE）を手書き追記 → `just migrate`
- [ ] `cd backend && just lint`（ruff + mypy）が通ること
- [ ] `PUT /api/v1/subscriptions/me` に Bearer JWT + `{\"keywords\":[\"diffusion model\",\"LLM\"]}` を送り、正規化された `keywords` と `is_active=true` が返ること
- [ ] `GET /api/v1/subscriptions/me` で保存内容が取得でき、未登録ユーザーは `{\"keywords\":[],\"is_active\":false}` が返ること
- [ ] トークンなし/匿名トークンで 401/403 になること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)