### PR TITLE
feat(backend): arXiv図アップロード時のPDF由来PNGの余白トリミング

### DIFF
--- a/backend/infrastructure/s3/s3_figure_storage_repository.py
+++ b/backend/infrastructure/s3/s3_figure_storage_repository.py
@@ -4,39 +4,45 @@ from logging import getLogger
 from pathlib import Path
 from typing import ClassVar
 
-from pdf2image import convert_from_path
-from PIL import Image, ImageChops
+import fitz
 
 from domain.repositories import IFigureStorageRepository
 from infrastructure.s3.client import build_public_url, create_s3_client
 from infrastructure.s3.config import get_s3_storage_config
 
+# 図PNGのレンダリング解像度。トリミングの閾値ではなく出力画質の設定。
+FIGURE_RENDER_DPI = 150
 
-def trim_whitespace(image: Image.Image, tolerance: int = 12, padding: int = 6) -> Image.Image:
-	"""Trim the near-white margins around a rasterized figure.
 
-	arXiv の LaTeX ソースに含まれる PDF 図はページ全面のキャンバスに小さく図が
-	配置されていることがあり、そのまま PNG 化すると周囲に大きな空白が残る。白背景
-	との差分から実際に内容のある領域の外接矩形を求め、その外側の余白のみを削る。
-	サブ図の間などの内側の空白は getbbox が全非背景ピクセルの外接矩形を返すため
-	保持される。全面が背景色（差分なし）の場合は元画像をそのまま返す。
+def render_pdf_figure_to_png(pdf_path: Path) -> bytes:
+	"""Render a figure PDF's first page to PNG, cropped to its actual content.
+
+	LaTeX の ``\\includegraphics`` が図PDFの内容領域だけを表示するのに倣い、ページ
+	全面ではなく実際に描画されている内容(テキスト・ベクター・埋め込み画像)の外接
+	矩形だけをラスタライズする。余白除去はピクセルの明度閾値ではなく内容のベクター
+	座標から厳密に決めるため(pdfcrop 相当)、tolerance や padding といった決め打ちの
+	定数を持たない。内容が検出できない場合はページ全体を描画する。
 	"""
-	rgb = image.convert('RGB')
-	background = Image.new('RGB', rgb.size, (255, 255, 255))
-	diff = ImageChops.difference(rgb, background)
-	if tolerance > 0:
-		# アンチエイリアス由来のほぼ白なピクセルを背景として扱う。
-		diff = diff.point(lambda p: 0 if p <= tolerance else p)
-	bbox = diff.getbbox()
-	if bbox is None:
-		return image
+	with fitz.open(pdf_path) as doc:
+		page = doc[0]
 
-	left, top, right, bottom = bbox
-	left = max(0, left - padding)
-	top = max(0, top - padding)
-	right = min(image.width, right + padding)
-	bottom = min(image.height, bottom + padding)
-	return image.crop((left, top, right, bottom))
+		content: fitz.Rect | None = None
+		rects = [drawing['rect'] for drawing in page.get_drawings()]
+		rects += [block['bbox'] for block in page.get_text('dict')['blocks']]
+		rects += [image['bbox'] for image in page.get_image_info()]
+		for raw_rect in rects:
+			rect = fitz.Rect(raw_rect)
+			if rect.is_empty or rect.is_infinite:
+				continue
+			content = rect if content is None else content | rect
+
+		clip = page.rect if content is None else content & page.rect
+		if clip.is_empty:
+			clip = page.rect
+
+		zoom = FIGURE_RENDER_DPI / 72.0
+		pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), clip=clip, colorspace=fitz.csRGB)
+		return pix.tobytes('png')
 
 
 class S3FigureStorageRepository(IFigureStorageRepository):
@@ -88,11 +94,10 @@ class S3FigureStorageRepository(IFigureStorageRepository):
 
 				if figure_file.suffix.lower() == '.pdf':
 					try:
-						images = convert_from_path(figure_file, dpi=150, first_page=1, last_page=1)
-						if not images:
-							raise RuntimeError(f'pdf2image returned no pages for {figure_file}')
+						png_bytes = render_pdf_figure_to_png(figure_file)
 						tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
-						trim_whitespace(images[0]).save(tmp.name, format='PNG')
+						tmp.write(png_bytes)
+						tmp.close()
 						upload_file = Path(tmp.name)
 						storage_filename = f'{figure_file.stem}.png'
 						is_tmp = True

--- a/backend/infrastructure/s3/s3_figure_storage_repository.py
+++ b/backend/infrastructure/s3/s3_figure_storage_repository.py
@@ -5,10 +5,38 @@ from pathlib import Path
 from typing import ClassVar
 
 from pdf2image import convert_from_path
+from PIL import Image, ImageChops
 
 from domain.repositories import IFigureStorageRepository
 from infrastructure.s3.client import build_public_url, create_s3_client
 from infrastructure.s3.config import get_s3_storage_config
+
+
+def trim_whitespace(image: Image.Image, tolerance: int = 12, padding: int = 6) -> Image.Image:
+	"""Trim the near-white margins around a rasterized figure.
+
+	arXiv の LaTeX ソースに含まれる PDF 図はページ全面のキャンバスに小さく図が
+	配置されていることがあり、そのまま PNG 化すると周囲に大きな空白が残る。白背景
+	との差分から実際に内容のある領域の外接矩形を求め、その外側の余白のみを削る。
+	サブ図の間などの内側の空白は getbbox が全非背景ピクセルの外接矩形を返すため
+	保持される。全面が背景色（差分なし）の場合は元画像をそのまま返す。
+	"""
+	rgb = image.convert('RGB')
+	background = Image.new('RGB', rgb.size, (255, 255, 255))
+	diff = ImageChops.difference(rgb, background)
+	if tolerance > 0:
+		# アンチエイリアス由来のほぼ白なピクセルを背景として扱う。
+		diff = diff.point(lambda p: 0 if p <= tolerance else p)
+	bbox = diff.getbbox()
+	if bbox is None:
+		return image
+
+	left, top, right, bottom = bbox
+	left = max(0, left - padding)
+	top = max(0, top - padding)
+	right = min(image.width, right + padding)
+	bottom = min(image.height, bottom + padding)
+	return image.crop((left, top, right, bottom))
 
 
 class S3FigureStorageRepository(IFigureStorageRepository):
@@ -64,7 +92,7 @@ class S3FigureStorageRepository(IFigureStorageRepository):
 						if not images:
 							raise RuntimeError(f'pdf2image returned no pages for {figure_file}')
 						tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
-						images[0].save(tmp.name, format='PNG')
+						trim_whitespace(images[0]).save(tmp.name, format='PNG')
 						upload_file = Path(tmp.name)
 						storage_filename = f'{figure_file.stem}.png'
 						is_tmp = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "feedparser>=6.0.11",
     "google-genai>=1.24.0",
     "pdf2image>=1.17.0",
+    "pillow>=10.0.0",
     "psycopg2-binary>=2.9.10",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.13.1",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = [
     "fastapi>=0.115.14",
     "feedparser>=6.0.11",
     "google-genai>=1.24.0",
-    "pdf2image>=1.17.0",
-    "pillow>=10.0.0",
+    "pymupdf>=1.25.0",
     "psycopg2-binary>=2.9.10",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.13.1",
@@ -52,5 +51,5 @@ python_version = "3.13"
 exclude = ["alembic/"]
 
 [[tool.mypy.overrides]]
-module = ["uuid6", "uuid6.*"]
+module = ["uuid6", "uuid6.*", "fitz", "fitz.*"]
 ignore_missing_imports = true

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -303,12 +303,12 @@ dependencies = [
     { name = "feedparser" },
     { name = "google-genai" },
     { name = "httpx" },
-    { name = "pdf2image" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "pylatex" },
+    { name = "pymupdf" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -346,12 +346,12 @@ requires-dist = [
     { name = "feedparser", specifier = ">=6.0.11" },
     { name = "google-genai", specifier = ">=1.24.0" },
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "pdf2image", specifier = ">=1.17.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pyjwt", specifier = ">=2.10.0" },
     { name = "pylatex", specifier = ">=1.4.2" },
+    { name = "pymupdf", specifier = ">=1.25.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -1115,76 +1115,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pdf2image"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pillow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/d8/b280f01045555dc257b8153c00dee3bc75830f91a744cd5f84ef3a0a64b1/pdf2image-1.17.0.tar.gz", hash = "sha256:eaa959bc116b420dd7ec415fcae49b98100dda3dd18cd2fdfa86d09f112f6d57", size = 12811, upload-time = "2024-01-07T20:33:01.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/33/61766ae033518957f877ab246f87ca30a85b778ebaad65b7f74fa7e52988/pdf2image-1.17.0-py3-none-any.whl", hash = "sha256:ecdd58d7afb810dffe21ef2b1bbc057ef434dabbac6c33778a38a3f7744a27e2", size = 11618, upload-time = "2024-01-07T20:32:59.957Z" },
-]
-
-[[package]]
-name = "pillow"
-version = "12.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
-    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d0/bebb3ffbf31c5a8e97241476c4cf8b9828954693ce6744b4a2326af3e16b/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af", size = 4062652, upload-time = "2026-02-11T04:21:53.19Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c0/0e16fb0addda4851445c28f8350d8c512f09de27bbb0d6d0bbf8b6709605/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f", size = 4138823, upload-time = "2026-02-11T04:22:03.088Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fb/6170ec655d6f6bb6630a013dd7cf7bc218423d7b5fa9071bf63dc32175ae/pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642", size = 3601143, upload-time = "2026-02-11T04:22:04.909Z" },
-    { url = "https://files.pythonhosted.org/packages/59/04/dc5c3f297510ba9a6837cbb318b87dd2b8f73eb41a43cc63767f65cb599c/pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd", size = 5266254, upload-time = "2026-02-11T04:22:07.656Z" },
-    { url = "https://files.pythonhosted.org/packages/05/30/5db1236b0d6313f03ebf97f5e17cda9ca060f524b2fcc875149a8360b21c/pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202", size = 4657499, upload-time = "2026-02-11T04:22:09.613Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/008d2ca0eb612e81968e8be0bbae5051efba24d52debf930126d7eaacbba/pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f", size = 6232137, upload-time = "2026-02-11T04:22:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/70/f1/f14d5b8eeb4b2cd62b9f9f847eb6605f103df89ef619ac68f92f748614ea/pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f", size = 8042721, upload-time = "2026-02-11T04:22:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/d6/17824509146e4babbdabf04d8171491fa9d776f7061ff6e727522df9bd03/pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f", size = 6347798, upload-time = "2026-02-11T04:22:15.449Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ee/c85a38a9ab92037a75615aba572c85ea51e605265036e00c5b67dfafbfe2/pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e", size = 7039315, upload-time = "2026-02-11T04:22:17.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f3/bc8ccc6e08a148290d7523bde4d9a0d6c981db34631390dc6e6ec34cacf6/pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0", size = 6462360, upload-time = "2026-02-11T04:22:19.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ab/69a42656adb1d0665ab051eec58a41f169ad295cf81ad45406963105408f/pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb", size = 7165438, upload-time = "2026-02-11T04:22:21.041Z" },
-    { url = "https://files.pythonhosted.org/packages/02/46/81f7aa8941873f0f01d4b55cc543b0a3d03ec2ee30d617a0448bf6bd6dec/pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f", size = 6431503, upload-time = "2026-02-11T04:22:22.833Z" },
-    { url = "https://files.pythonhosted.org/packages/40/72/4c245f7d1044b67affc7f134a09ea619d4895333d35322b775b928180044/pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15", size = 7176748, upload-time = "2026-02-11T04:22:24.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ad/8a87bdbe038c5c698736e3348af5c2194ffb872ea52f11894c95f9305435/pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f", size = 2544314, upload-time = "2026-02-11T04:22:26.685Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9d/efd18493f9de13b87ede7c47e69184b9e859e4427225ea962e32e56a49bc/pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8", size = 5268612, upload-time = "2026-02-11T04:22:29.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f1/4f42eb2b388eb2ffc660dcb7f7b556c1015c53ebd5f7f754965ef997585b/pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9", size = 4660567, upload-time = "2026-02-11T04:22:31.799Z" },
-    { url = "https://files.pythonhosted.org/packages/01/54/df6ef130fa43e4b82e32624a7b821a2be1c5653a5fdad8469687a7db4e00/pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60", size = 6269951, upload-time = "2026-02-11T04:22:33.921Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/48/618752d06cc44bb4aae8ce0cd4e6426871929ed7b46215638088270d9b34/pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7", size = 8074769, upload-time = "2026-02-11T04:22:35.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/bd/f1d71eb39a72fa088d938655afba3e00b38018d052752f435838961127d8/pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f", size = 6381358, upload-time = "2026-02-11T04:22:37.698Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ef/c784e20b96674ed36a5af839305f55616f8b4f8aa8eeccf8531a6e312243/pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586", size = 7068558, upload-time = "2026-02-11T04:22:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cb/8059688b74422ae61278202c4e1ad992e8a2e7375227be0a21c6b87ca8d5/pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce", size = 6493028, upload-time = "2026-02-11T04:22:42.73Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/da/e3c008ed7d2dd1f905b15949325934510b9d1931e5df999bb15972756818/pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8", size = 7191940, upload-time = "2026-02-11T04:22:44.543Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
-]
-
-[[package]]
 name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1411,6 +1341,23 @@ dependencies = [
     { name = "ordered-set" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/a8/10cf6b955b5fa19438790d9949867e04c785ae845e631c5ef6db444401d1/PyLaTeX-1.4.2.tar.gz", hash = "sha256:bb7b21bec57ecdba3f6f44c856ebebdf6549fd6e80661bd44fd5094236729242", size = 59710, upload-time = "2023-10-19T16:22:54.096Z" }
+
+[[package]]
+name = "pymupdf"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e9/6d6c5d6c0a3551bffd47681a6240caf941727f195b45593cf20ab36f018f/pymupdf-1.28.0.tar.gz", hash = "sha256:e53f3567403a92da15caa9e7ae0164327fff48817e9f40175367fb9de524258d", size = 87637751, upload-time = "2026-06-29T09:08:47.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/b7/88043e38cc7529de070f0c9bd267fa258035cca0b4ad5260536b994594a7/pymupdf-1.28.0-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:892b89ba88e8f98b53133b62877a9dc9b5e7dc6a4aeb837b612db56a8d2e03ac", size = 24597385, upload-time = "2026-06-29T09:03:30.608Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f4/23775bbda0781b61fc398cc75079a2b0e64696d8fcf93271748883e9627e/pymupdf-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4d692dcf44d3566ae96bc6f6346c6ad432274a29ba617bf7a9fe18009e24adb4", size = 23828292, upload-time = "2026-06-29T09:03:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/bf75fc7a415722f8b33662054f82d88520c0cbfd4c36d0e08aeaec605e49/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:47a5c29ed4eb0744de9c4e37bb49b1259b18d4d75fcc8a7c130f7c9fa15956f6", size = 25045507, upload-time = "2026-06-29T09:04:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/58/69/5d12c9f1f2d76f28383d6110a069c79fbfced5a4f97bb1ee6e8354f52bb7/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:44f0973f5e5edbaec95bc34b64e71d1959d4ee90b1328de1b4f4f5b4fa78673f", size = 25716599, upload-time = "2026-06-29T09:04:19.367Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/ec0e017bc42857cc86bd651441dbc41cc18be48d4698ecd27aac491e0c9a/pymupdf-1.28.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4d61ec323a706e153a12e262e51febfb43eeaa20977785ace135d18d48bcdc83", size = 25940489, upload-time = "2026-06-29T09:04:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/06/86/f831fef09013f33b3c9c09fb3923f2ff53e1e437f6ace14b8ae46392f558/pymupdf-1.28.0-cp310-abi3-win32.whl", hash = "sha256:caea2b3b67347fd79e5d15ed7929b0e886aac594ea228073b6d39de0078189da", size = 18489703, upload-time = "2026-06-29T20:50:30.599Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:e01e90fd86abfeb37ceb921eddb951f988a11d45ff6ce6b7664f2039849068ec", size = 19773102, upload-time = "2026-06-29T09:04:49.773Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/1e52ce243ca792254f6223b4017c5667194c146ce9b88baf37bc5eb3d1c9/pymupdf-1.28.0-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:74c6d00ba2a9aad3a635db73b07c15db462b480741d831a34a75a56535ebc22b", size = 18357011, upload-time = "2026-06-29T20:50:50.353Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b1/46b5b3d8ef3cc71114667cf10c4d8b33f39af97253af32e9a0986775b638/pymupdf-1.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b3e1399c7a64c6914239116a369efcdaac4cfb9e838bde2656d7accc4a85c72d", size = 25753599, upload-time = "2026-06-29T09:05:09.398Z" },
+]
 
 [[package]]
 name = "python-dateutil"

--- a/pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py
+++ b/pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py
@@ -8,7 +8,7 @@ import cv2
 import fitz
 import numpy as np
 import onnxruntime as ort
-from PIL import Image, ImageChops
+from PIL import Image
 
 from domain.entities.figure import ExtractedFigure
 from domain.errors.extraction_error import FigureExtractionError
@@ -17,34 +17,6 @@ from domain.gateways.figure_extractor import FigureExtractorGateway
 FIGURE_NUMBER_RE: re.Pattern[str] = re.compile(
     r"(?:Fig(?:ure)?|図)\s*\.?\s*(\d+)", re.IGNORECASE
 )
-
-
-def trim_whitespace(
-    image: Image.Image, tolerance: int = 12, padding: int = 6
-) -> Image.Image:
-    """Trim the near-white margins around a figure crop.
-
-    DocLayout-YOLO の bbox はページ余白を含んで緩めに出ることがあり、その結果
-    図の周囲に空白が残る。白背景との差分から実際に内容のある領域の外接矩形を求め、
-    その外側の余白だけを削る。サブ図の間などの内側の空白は getbbox が全非背景
-    ピクセルの外接矩形を返すため保持される。全面が背景色の場合は元画像を返す。
-    """
-    rgb = image.convert("RGB")
-    background = Image.new("RGB", rgb.size, (255, 255, 255))
-    diff = ImageChops.difference(rgb, background)
-    if tolerance > 0:
-        # アンチエイリアス由来のほぼ白なピクセルを背景として扱う。
-        diff = diff.point(lambda p: 0 if p <= tolerance else p)
-    bbox = diff.getbbox()
-    if bbox is None:
-        return image
-
-    left, top, right, bottom = bbox
-    left = max(0, left - padding)
-    top = max(0, top - padding)
-    right = min(image.width, right + padding)
-    bottom = min(image.height, bottom + padding)
-    return image.crop((left, top, right, bottom))
 
 
 class PdfFigureExtractor(FigureExtractorGateway):
@@ -147,15 +119,14 @@ class PdfFigureExtractor(FigureExtractorGateway):
                         break
 
                     buf = io.BytesIO()
-                    cropped = page_img.crop(
+                    page_img.crop(
                         (
                             int(fig_bbox[0]),
                             int(fig_bbox[1]),
                             int(fig_bbox[2]),
                             int(fig_bbox[3]),
                         )
-                    )
-                    trim_whitespace(cropped).save(buf, format="PNG")
+                    ).save(buf, format="PNG")
 
                     caption_text = ""
                     figure_number = None

--- a/pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py
+++ b/pdf_analysis/infrastructure/onnx/pdf_figure_extractor.py
@@ -8,7 +8,7 @@ import cv2
 import fitz
 import numpy as np
 import onnxruntime as ort
-from PIL import Image
+from PIL import Image, ImageChops
 
 from domain.entities.figure import ExtractedFigure
 from domain.errors.extraction_error import FigureExtractionError
@@ -17,6 +17,34 @@ from domain.gateways.figure_extractor import FigureExtractorGateway
 FIGURE_NUMBER_RE: re.Pattern[str] = re.compile(
     r"(?:Fig(?:ure)?|図)\s*\.?\s*(\d+)", re.IGNORECASE
 )
+
+
+def trim_whitespace(
+    image: Image.Image, tolerance: int = 12, padding: int = 6
+) -> Image.Image:
+    """Trim the near-white margins around a figure crop.
+
+    DocLayout-YOLO の bbox はページ余白を含んで緩めに出ることがあり、その結果
+    図の周囲に空白が残る。白背景との差分から実際に内容のある領域の外接矩形を求め、
+    その外側の余白だけを削る。サブ図の間などの内側の空白は getbbox が全非背景
+    ピクセルの外接矩形を返すため保持される。全面が背景色の場合は元画像を返す。
+    """
+    rgb = image.convert("RGB")
+    background = Image.new("RGB", rgb.size, (255, 255, 255))
+    diff = ImageChops.difference(rgb, background)
+    if tolerance > 0:
+        # アンチエイリアス由来のほぼ白なピクセルを背景として扱う。
+        diff = diff.point(lambda p: 0 if p <= tolerance else p)
+    bbox = diff.getbbox()
+    if bbox is None:
+        return image
+
+    left, top, right, bottom = bbox
+    left = max(0, left - padding)
+    top = max(0, top - padding)
+    right = min(image.width, right + padding)
+    bottom = min(image.height, bottom + padding)
+    return image.crop((left, top, right, bottom))
 
 
 class PdfFigureExtractor(FigureExtractorGateway):
@@ -119,14 +147,15 @@ class PdfFigureExtractor(FigureExtractorGateway):
                         break
 
                     buf = io.BytesIO()
-                    page_img.crop(
+                    cropped = page_img.crop(
                         (
                             int(fig_bbox[0]),
                             int(fig_bbox[1]),
                             int(fig_bbox[2]),
                             int(fig_bbox[3]),
                         )
-                    ).save(buf, format="PNG")
+                    )
+                    trim_whitespace(cropped).save(buf, format="PNG")
 
                     caption_text = ""
                     figure_number = None


### PR DESCRIPTION
## 背景 / 課題

arXiv 論文の **LaTeX ソース経路**（`generate_blog_post.py` → `S3FigureStorageRepository.upload_figures`）では、ソース tarball に含まれる図アセットを拾ってアップロードしています。このうち **`.pdf` 図**をラスタライズする際、ページ全面を描画していたため、図がキャンバスの一角にしか無いPDFで周囲に**大きな空白**が残り、そのままブログに反映されていました。

### なぜ LaTeX 本体では起きないか
`\includegraphics{fig.pdf}` は空白をピクセル検出しているのではなく、**PDFの内容領域（バウンディングボックス）だけを描画**します。本パイプラインは LaTeX をコンパイルせず生PDFをページごとラスタライズしていたため、その恩恵を受けられていませんでした。

## アプローチ

当初はレンダリング後の PNG を明度閾値でトリミングしていましたが、`tolerance`/`padding` の決め打ちは白背景に近い図やカラー背景で例外を生む場当たり的な手法でした。レビューを受け、**LaTeX の流儀に倣った内容ベースの方式**に作り替えています。

- **PyMuPDF で図PDFを開き、実描画内容（テキスト・ベクター・埋め込み画像）の外接矩形をベクター座標から算出し、その領域だけをレンダリング**（`pdfcrop` 相当）
- 余白除去はピクセルの明度ではなく内容座標から厳密に決まるため、**閾値・パディングの魔法定数を一切持たない**
- 内容が検出できないPDFはページ全体にフォールバック

## 変更内容

`backend/infrastructure/s3/s3_figure_storage_repository.py`
- `render_pdf_figure_to_png(pdf_path)` を追加（内容bbox算出 → clip指定でレンダリング）
- `upload_figures` の PDF 分岐を本関数の呼び出しに置換

`backend/pyproject.toml` / `backend/uv.lock`
- `pdf2image` / `pillow` への依存を削除し `pymupdf>=1.25.0` を追加、`uv.lock` を再生成（Codex 指摘対応）
- `fitz` を mypy の `ignore_missing_imports` に追加

（DocLayout-YOLO を使う `PdfFigureExtractor` 経路はこの問題の対象外のため変更していません。）

## 検証

- `ruff check` / `ruff format --check` / `mypy`（対象ファイル）通過
- PyMuPDF でレンダリングロジックを検証
  - ページ全面キャンバスの左上にのみ内容があるPDF → 全面(≈1239×1754px)ではなく内容領域(≈313×320px)だけを出力 ✅
  - 内容が無い空ページ → ページ全体にフォールバック ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)